### PR TITLE
fix(1337): close bet/winner race so /stats stays consistent

### DIFF
--- a/commands/bet_1337_command.py
+++ b/commands/bet_1337_command.py
@@ -49,7 +49,7 @@ class Bet1337Command(commands.Cog):
             play_time = datetime.now()
             logger.debug(f"Current time: {self.game_logic.format_time_with_ms(play_time)}")
 
-            success = self.game_logic.save_bet(
+            status = self.game_logic.save_bet(
                 interaction.user.id,
                 interaction.user.display_name,
                 play_time,
@@ -58,7 +58,7 @@ class Bet1337Command(commands.Cog):
                 interaction.channel_id
             )
 
-            if success:
+            if status == 'saved':
                 logger.info(f"Regular bet saved successfully for {interaction.user.display_name} at {self.game_logic.format_time_with_ms(play_time)}")
 
                 # Check if user is General and announce
@@ -70,6 +70,12 @@ class Bet1337Command(commands.Cog):
 
                 await interaction.response.send_message(
                     f"✅ **Bet placed!** Your time: {self.game_logic.format_time_with_ms(play_time)}\nGood luck! 🍀",
+                    ephemeral=True
+                )
+            elif status == 'game_closed':
+                logger.info(f"Bet from {interaction.user.display_name} lost race with winner determination")
+                await interaction.response.send_message(
+                    "❌ **The game just ended.** A winner was determined a moment ago — try again tomorrow!",
                     ephemeral=True
                 )
             else:

--- a/commands/bet_1337_early_bird_command.py
+++ b/commands/bet_1337_early_bird_command.py
@@ -54,7 +54,7 @@ class Bet1337EarlyBirdCommand(commands.Cog):
             play_time = timestamp_validation['timestamp']
             
             # Save the bet
-            success = self.game_logic.save_bet(
+            status = self.game_logic.save_bet(
                 interaction.user.id,
                 interaction.user.display_name,
                 play_time,
@@ -63,7 +63,7 @@ class Bet1337EarlyBirdCommand(commands.Cog):
                 interaction.channel_id
             )
 
-            if success:
+            if status == 'saved':
                 # Check if user is General and announce
                 if Config.GENERAL_ROLE_ID:
                     general_role = interaction.guild.get_role(Config.GENERAL_ROLE_ID)
@@ -72,6 +72,11 @@ class Bet1337EarlyBirdCommand(commands.Cog):
 
                 await interaction.response.send_message(
                     f"✅ **Early bird bet scheduled!** Your time: {self.game_logic.format_time_with_ms(play_time)}\nGood luck! 🍀",
+                    ephemeral=True
+                )
+            elif status == 'game_closed':
+                await interaction.response.send_message(
+                    "❌ **The game just ended.** A winner was determined a moment ago — try again tomorrow!",
                     ephemeral=True
                 )
             else:

--- a/commands/game_1337_command.py
+++ b/commands/game_1337_command.py
@@ -128,31 +128,8 @@ class Game1337Command(commands.Cog):
                 time_diff = (actual_time - win_time).total_seconds() * 1000  # Convert to milliseconds
                 logger.info(f"Winner determination triggered at: {self.game_logic.format_time_with_ms(actual_time)} (diff: {time_diff:.1f}ms)")
 
-            try:
-                logger.debug(f"Determining winner for {game_date} at {win_time}")
-                winner_result = self.game_logic.determine_winner(game_date, win_time)
-                logger.debug(f"Winner result: {winner_result}")
-            except Exception as e:
-                logger.error(f"Error determining winner: {e}", exc_info=True)
-                return
-
-            if not winner_result:
-                logger.info(f"No winner for {game_date}")
-                try:
-                    await self._announce_no_winner()
-                except Exception as e:
-                    logger.error(f"Error announcing no winner: {e}", exc_info=True)
-                return
-
-            if winner_result.get('catastrophic_event'):
-                logger.info(f"Catastrophic event detected for {game_date}")
-                try:
-                    await self._announce_catastrophic_event()
-                except Exception as e:
-                    logger.error(f"Error announcing catastrophic event: {e}", exc_info=True)
-                return
-
-            # Get current role holders before updating roles
+            # Snapshot current role holders BEFORE the atomic decision so the
+            # announcement message reflects the role state at decision time.
             current_role_holders = {}
             try:
                 logger.debug(f"Getting current role holders for {len(self.bot.guilds)} guilds")
@@ -173,26 +150,46 @@ class Game1337Command(commands.Cog):
                 logger.error(f"Error getting current role holders: {e}", exc_info=True)
                 current_role_holders = {}
 
-            # Save winner to database
+            # Atomic: lock the winner row, read bets, pick + persist. The same
+            # lock blocks any concurrent bet insert (see database.save_1337_bet),
+            # so the persisted winner is computed from the same set of bets
+            # that /stats will later display.
             try:
-                logger.debug(f"Saving winner to database: {winner_result}")
-                success = self.game_logic.save_winner(winner_result)
-                logger.debug(f"Save winner result: {success}")
+                logger.debug(f"Atomically deciding winner for {game_date} at {win_time}")
+                winner_result = self.game_logic.determine_and_save_winner(game_date, win_time)
+                logger.debug(f"Winner result: {winner_result}")
             except Exception as e:
-                logger.error(f"Error saving winner to database: {e}", exc_info=True)
-                success = False
+                logger.error(f"Error in atomic winner decision: {e}", exc_info=True)
+                return
 
-            if success:
-                logger.info(f"Winner saved to database successfully")
+            if winner_result and winner_result.get('already_decided'):
+                logger.info(f"Winner for {game_date} already decided in a prior run; skipping announcement")
+                return
+
+            if not winner_result:
+                logger.info(f"No winner for {game_date}")
                 try:
-                    logger.debug("Updating roles...")
-                    await self._update_roles()
-                    logger.debug("Announcing winner...")
-                    await self._announce_winner(winner_result, current_role_holders)
+                    await self._announce_no_winner()
                 except Exception as e:
-                    logger.error(f"Error in post-save operations: {e}", exc_info=True)
-            else:
-                logger.error(f"Failed to save winner to database")
+                    logger.error(f"Error announcing no winner: {e}", exc_info=True)
+                return
+
+            if winner_result.get('catastrophic_event'):
+                logger.info(f"Catastrophic event detected for {game_date}")
+                try:
+                    await self._announce_catastrophic_event()
+                except Exception as e:
+                    logger.error(f"Error announcing catastrophic event: {e}", exc_info=True)
+                return
+
+            logger.info(f"Winner saved to database successfully")
+            try:
+                logger.debug("Updating roles...")
+                await self._update_roles()
+                logger.debug("Announcing winner...")
+                await self._announce_winner(winner_result, current_role_holders)
+            except Exception as e:
+                logger.error(f"Error in post-save operations: {e}", exc_info=True)
 
             logger.info(f"Winner determination complete for {game_date}: {winner_result.get('username', 'Unknown')}")
         

--- a/database.py
+++ b/database.py
@@ -363,10 +363,34 @@ class DatabaseManager:
                 connection.close()
     
     def save_1337_bet(self, user_id, username, play_time, game_date, bet_type='regular', server_id=None, channel_id=None):
+        """Save a bet, refusing if a winner has already been determined for game_date.
+
+        Returns: 'saved' | 'game_closed' | 'error'.
+
+        The SELECT ... FOR UPDATE on game_1337_winners(game_date) acquires a
+        next-key gap lock when the row is absent, which serializes against the
+        winner-determination transaction in decide_winner_atomically. Either
+        the winner row is already visible (we reject), or our bet INSERT
+        commits first and the winner-determination path observes our row.
+        """
         connection = None
         try:
             connection = self._get_connection()
+            connection.autocommit = False
             cursor = connection.cursor()
+
+            cursor.execute(
+                "SELECT 1 FROM game_1337_winners WHERE game_date = ? FOR UPDATE",
+                (game_date,),
+            )
+            if cursor.fetchone() is not None:
+                connection.rollback()
+                logger.info(
+                    f"Bet rejected for {username} ({user_id}) on {game_date}: "
+                    f"winner already determined"
+                )
+                return 'game_closed'
+
             cursor.execute("""
                 INSERT INTO game_1337_bets (user_id, username, play_time, game_date, bet_type, server_id, channel_id)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -375,13 +399,18 @@ class DatabaseManager:
                 bet_type = VALUES(bet_type),
                 username = VALUES(username)
             """, (user_id, username, play_time, game_date, bet_type, server_id, channel_id))
-            
+
             connection.commit()
             logger.info(f"Saved 1337 bet for user {username} ({user_id}) on {game_date}")
-            return True
+            return 'saved'
         except mariadb.Error as e:
+            if connection:
+                try:
+                    connection.rollback()
+                except mariadb.Error:
+                    pass
             logger.error(f"Error saving 1337 bet: {e}")
-            return False
+            return 'error'
         finally:
             if connection:
                 connection.close()
@@ -470,7 +499,96 @@ class DatabaseManager:
         finally:
             if connection:
                 connection.close()
-    
+
+    def decide_winner_atomically(self, game_date, win_time, pick_winner):
+        """Atomically lock today's winner row, read bets, pick a winner, and persist.
+
+        Holds a SELECT ... FOR UPDATE gap lock on game_1337_winners(game_date)
+        across reading bets and inserting the winner. Bet inserts in
+        save_1337_bet take the same lock, so no bet can land between the read
+        and the winner insert: either the bet commits first and we observe it,
+        or it blocks until we commit and then rejects with 'game_closed'.
+
+        pick_winner(bets, win_time) -> Optional[dict]
+            Returns one of:
+              - None for "no eligible winner today"
+              - {'catastrophic_event': True, 'identical_count': N}
+              - winner dict with keys: user_id, username, play_time, bet_type,
+                millisecond_diff, server_id (server_id may be None)
+
+        Returns the picker's result, or None if a winner was already recorded
+        (idempotent re-entry).
+        """
+        connection = None
+        try:
+            connection = self._get_connection()
+            connection.autocommit = False
+            cursor = connection.cursor()
+
+            cursor.execute(
+                "SELECT 1 FROM game_1337_winners WHERE game_date = ? FOR UPDATE",
+                (game_date,),
+            )
+            if cursor.fetchone() is not None:
+                connection.rollback()
+                logger.info(f"Winner already recorded for {game_date}; skipping re-decision")
+                # Distinct from "no eligible bets" — the caller must not
+                # announce "no winner today" in this case.
+                return {'already_decided': True}
+
+            cursor.execute("""
+                SELECT user_id, username, play_time, bet_type, server_id, channel_id
+                FROM game_1337_bets
+                WHERE game_date = ?
+                ORDER BY play_time ASC
+            """, (game_date,))
+            bets = [
+                {
+                    'user_id': row[0],
+                    'username': row[1],
+                    'play_time': row[2],
+                    'bet_type': row[3],
+                    'server_id': row[4],
+                    'channel_id': row[5],
+                }
+                for row in cursor.fetchall()
+            ]
+
+            picked = pick_winner(bets, win_time)
+
+            if picked is None or picked.get('catastrophic_event'):
+                connection.rollback()
+                return picked
+
+            cursor.execute("""
+                INSERT INTO game_1337_winners
+                    (user_id, username, game_date, win_time, play_time,
+                     bet_type, millisecond_diff, server_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                picked['user_id'], picked['username'], game_date,
+                win_time, picked['play_time'], picked['bet_type'],
+                picked['millisecond_diff'], picked.get('server_id'),
+            ))
+            connection.commit()
+            logger.info(
+                f"Atomically decided 1337 winner for {game_date}: "
+                f"{picked['username']} ({picked['user_id']})"
+            )
+            return picked
+
+        except mariadb.Error as e:
+            if connection:
+                try:
+                    connection.rollback()
+                except mariadb.Error:
+                    pass
+            logger.error(f"Error in decide_winner_atomically: {e}")
+            raise
+        finally:
+            if connection:
+                connection.close()
+
     def get_winner_stats(self, user_id=None, days=None):
         connection = None
         try:

--- a/game/game_1337_logic.py
+++ b/game/game_1337_logic.py
@@ -153,18 +153,14 @@ class Game1337Logic:
         """Calculate millisecond difference between bet time and win time"""
         return int((win_time - bet_time).total_seconds() * 1000)
 
-    def determine_winner(self, game_date: date, win_time: datetime) -> Optional[Dict[str, Any]]:
-        """
-        Determine the winner for a given game date and win time.
-        Returns the winner dict or None if no winner/catastrophic event.
-        """
-        logger.info(f"Determining winner for {game_date}, win time: {self.format_time_with_ms(win_time)}")
+    def _select_winner_from_bets(self, daily_bets: List[Dict[str, Any]], win_time: datetime) -> Optional[Dict[str, Any]]:
+        """Pure selection: pick a winner from an already-loaded list of bets.
 
-        daily_bets = self.db_manager.get_daily_bets(game_date)
-        logger.debug(f"Found {len(daily_bets)} total bets for {game_date}")
-
+        Returns None, a catastrophic-event marker, or the winner dict
+        (with millisecond_diff and win_time populated). No DB access.
+        """
         valid_bets = [bet for bet in daily_bets if bet['play_time'] <= win_time]
-        logger.debug(f"Found {len(valid_bets)} valid bets (≤ win time)")
+        logger.debug(f"Found {len(valid_bets)} valid bets (≤ win time) out of {len(daily_bets)} total")
 
         for bet in daily_bets:
             valid = "✓" if bet['play_time'] <= win_time else "✗"
@@ -173,7 +169,7 @@ class Game1337Logic:
             )
 
         if not valid_bets:
-            logger.info(f"No valid bets for {game_date}")
+            logger.info("No valid bets")
             return None
 
         if len(valid_bets) == 1:
@@ -185,7 +181,6 @@ class Game1337Logic:
                 logger.info("No winner determined")
                 return None
 
-        # Check for catastrophic event (identical times)
         identical_times = [bet for bet in valid_bets if bet['play_time'] == winner['play_time']]
         if len(identical_times) > 1:
             logger.info(
@@ -200,12 +195,29 @@ class Game1337Logic:
             f"({winner['bet_type']}) - {millisecond_diff}ms before win time"
         )
 
-        # Add calculated difference to winner data
         winner_data = winner.copy()
         winner_data['millisecond_diff'] = millisecond_diff
         winner_data['win_time'] = win_time
-        
         return winner_data
+
+    def determine_winner(self, game_date: date, win_time: datetime) -> Optional[Dict[str, Any]]:
+        """Non-transactional read + selection. Kept for tests and ad-hoc use.
+
+        Production should call determine_and_save_winner, which holds a lock
+        across the read and the winner insert to keep /stats consistent with
+        the announced winner.
+        """
+        logger.info(f"Determining winner for {game_date}, win time: {self.format_time_with_ms(win_time)}")
+        daily_bets = self.db_manager.get_daily_bets(game_date)
+        logger.debug(f"Found {len(daily_bets)} total bets for {game_date}")
+        return self._select_winner_from_bets(daily_bets, win_time)
+
+    def determine_and_save_winner(self, game_date: date, win_time: datetime) -> Optional[Dict[str, Any]]:
+        """Atomic read + select + persist. Use this from the scheduler path."""
+        logger.info(f"Atomically deciding winner for {game_date}, win time: {self.format_time_with_ms(win_time)}")
+        return self.db_manager.decide_winner_atomically(
+            game_date, win_time, self._select_winner_from_bets
+        )
 
     def get_milliseconds_since_midnight(self, dt: datetime) -> int:
         """Get milliseconds since midnight for a datetime object"""
@@ -268,19 +280,6 @@ class Game1337Logic:
             logger.debug(f"Winner: {closest_regular['username']} (early_bird closer but within 3s of regular)")
             return closest_regular
 
-    def save_winner(self, winner_data: Dict[str, Any]) -> bool:
-        """Save the winner to the database"""
-        return self.db_manager.save_1337_winner(
-            winner_data['user_id'],
-            winner_data['username'],
-            winner_data['win_time'].date(),
-            winner_data['win_time'],
-            winner_data['play_time'],
-            winner_data['bet_type'],
-            winner_data['millisecond_diff'],
-            winner_data['server_id']
-        )
-
     def validate_bet_placement(self, user_id: int, current_time: Optional[datetime] = None) -> Dict[str, Any]:
         """
         Validate if a bet can be placed.
@@ -288,9 +287,19 @@ class Game1337Logic:
         """
         if current_time is None:
             current_time = datetime.now()
-        
+
         game_date = self.get_game_date()
-        
+
+        # Soft pre-check: if the winner has already been recorded, the day is
+        # over regardless of the 1-minute buffer. The hard guarantee lives in
+        # save_1337_bet's transactional gap lock; this is the friendly message.
+        if self.db_manager.get_daily_winner(game_date):
+            return {
+                'valid': False,
+                'reason': 'game_closed',
+                'message': "❌ **The game is over for today.** Try again tomorrow!"
+            }
+
         # Check if game time has passed
         if self.is_game_time_passed(current_time):
             return {
@@ -298,7 +307,7 @@ class Game1337Logic:
                 'reason': 'game_time_passed',
                 'message': "❌ **Game time has passed!** The 1337 window is closed for today. Try again tomorrow!"
             }
-        
+
         # Check if user already has a bet
         existing_bet = self.db_manager.get_user_bet(user_id, game_date)
         if existing_bet:
@@ -347,9 +356,13 @@ class Game1337Logic:
             'timestamp': parsed_timestamp
         }
 
-    def save_bet(self, user_id: int, username: str, play_time: datetime, bet_type: str, 
-                 guild_id: int, channel_id: int) -> bool:
-        """Save a bet to the database"""
+    def save_bet(self, user_id: int, username: str, play_time: datetime, bet_type: str,
+                 guild_id: int, channel_id: int) -> str:
+        """Save a bet. Returns 'saved' | 'game_closed' | 'error'.
+
+        'game_closed' means the bet lost a race against winner determination:
+        a winner row was written between validate_bet_placement and this call.
+        """
         game_date = self.get_game_date()
         return self.db_manager.save_1337_bet(
             user_id, username, play_time, game_date, bet_type, guild_id, channel_id

--- a/tests/test_game_1337_logic.py
+++ b/tests/test_game_1337_logic.py
@@ -280,37 +280,56 @@ class TestGame1337Logic(unittest.TestCase):
 
     def test_validate_bet_placement_success(self):
         """Test successful bet placement validation"""
+        self.db_manager.get_daily_winner.return_value = None
         self.db_manager.get_user_bet.return_value = None  # No existing bet
-        
+
         with patch('game.game_1337_logic.Config.GAME_START_TIME', '13:37:00.000'):
             current_time = datetime(2023, 12, 25, 13, 30, 0)  # Before deadline
             result = self.logic.validate_bet_placement(12345, current_time)
-            
+
             self.assertTrue(result['valid'])
 
     def test_validate_bet_placement_game_passed(self):
         """Test bet placement validation when game time has passed"""
+        self.db_manager.get_daily_winner.return_value = None
         with patch('game.game_1337_logic.Config.GAME_START_TIME', '13:37:00.000'):
             current_time = datetime(2023, 12, 25, 13, 40, 0)  # After deadline
             result = self.logic.validate_bet_placement(12345, current_time)
-            
+
             self.assertFalse(result['valid'])
             self.assertEqual(result['reason'], 'game_time_passed')
 
     def test_validate_bet_placement_existing_bet(self):
         """Test bet placement validation when user already has a bet"""
+        self.db_manager.get_daily_winner.return_value = None
         existing_bet = {
             'bet_type': 'regular',
             'play_time': datetime(2023, 12, 25, 13, 30, 0)
         }
         self.db_manager.get_user_bet.return_value = existing_bet
-        
+
         with patch('game.game_1337_logic.Config.GAME_START_TIME', '13:37:00.000'):
             current_time = datetime(2023, 12, 25, 13, 30, 0)
             result = self.logic.validate_bet_placement(12345, current_time)
-            
+
             self.assertFalse(result['valid'])
             self.assertEqual(result['reason'], 'existing_bet')
+
+    def test_validate_bet_placement_game_closed(self):
+        """Validation must reject once a winner has been recorded for today,
+        even before the 1-minute buffer expires."""
+        self.db_manager.get_daily_winner.return_value = {
+            'user_id': 999, 'username': 'SomeoneElse'
+        }
+        with patch('game.game_1337_logic.Config.GAME_START_TIME', '13:37:00.000'):
+            # Inside the 1-minute buffer (would pass the old check)
+            current_time = datetime(2023, 12, 25, 13, 37, 45)
+            result = self.logic.validate_bet_placement(12345, current_time)
+
+            self.assertFalse(result['valid'])
+            self.assertEqual(result['reason'], 'game_closed')
+            # get_user_bet must not even be consulted once we know the game is over
+            self.db_manager.get_user_bet.assert_not_called()
 
     def test_validate_early_bird_timestamp_success(self):
         """Test successful early bird timestamp validation"""


### PR DESCRIPTION
## Summary

- Closes a race where bets placed between winner determination and the end of the 1-minute buffer were silently accepted with `✅ Bet placed!` even though they had no chance to win.
- Closes a worse race where a bet could land between `determine_winner`'s read and the winner-row write, ending up visible in `/stats` with a `play_time` closer to `win_time` than the announced winner — letting any user see direct proof of the inconsistency.
- `/stats` is now guaranteed coherent: every bet shown was visible to the picker, and the announced winner is the best among them.

Real-world trigger from `2026-05-17` logs: heeecker's bet landed at `13:37:28.793`, after the winner row had already been written at `13:37:28.111`. Bot replied "Bet placed!" anyway.

## How it works

Three coordinated fixes, all keyed on a `SELECT … FOR UPDATE` next-key gap lock on `game_1337_winners(game_date)`:

1. **Soft gate** — `validate_bet_placement` refuses bets when a winner row already exists for today (`reason='game_closed'`). Friendly fast path before the user's interaction-response timeout becomes a worry.
2. **Hard gate on the bet side** — `save_1337_bet` now opens a transaction, takes the gap lock, and only inserts if no winner row exists. Returns `'saved' | 'game_closed' | 'error'`; the command layer maps these to distinct user-facing messages.
3. **Hard gate on the decider side** — new `decide_winner_atomically` holds the same gap lock across reading bets and inserting the winner. Either a concurrent bet commits first (and is considered for winning), or it blocks until after the winner is recorded (and is then rejected with `'game_closed'`).

Selection logic was extracted into a pure `_select_winner_from_bets(bets, win_time)` helper, so the legacy `determine_winner` is preserved unchanged for tests and ad-hoc use, while the scheduler calls the new transactional `determine_and_save_winner`.

Re-entry is idempotent: if a winner is already recorded (cog reload, bot bounce, multi-replica scheduler), `decide_winner_atomically` returns `{'already_decided': True}` and the cog skips re-announcement instead of mistakenly announcing "no winner today".

## DB prerequisites (verified on prod)

- `game_1337_bets` and `game_1337_winners` are InnoDB ✓
- Global/session isolation is `REPEATABLE-READ` ✓
- `game_1337_winners` has a UNIQUE BTREE index on `game_date` (next-key lock granularity for the missing row) ✓

No schema migration needed.

## Test plan

- [x] `python -m unittest discover tests` — 85/85 pass locally
- [x] Added `test_validate_bet_placement_game_closed` covering the new soft-gate branch and asserting `get_user_bet` is not called once the game is over
- [x] Existing validate tests updated to explicitly stub `get_daily_winner` (was implicitly truthy via Mock)
- [ ] Production validation at the next 13:37: watch logs for `Bet rejected for X (Y) on Z: winner already determined` (expected, not an error) and confirm `/stats` page-2 list matches the announced winner

## Rollout / rollback

- Pure code change, no schema migration. Straight restart is fine for a single-instance deploy.
- Do NOT mixed-deploy old/new replicas across a 13:37 boundary — old replicas don't take the gap lock and would silently reintroduce the original race.
- Rollback: `git revert` of the touched files, no data cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)