### PR TITLE
Add top-3 / close-race / way-off report to 1337 winner announcement

### DIFF
--- a/game/game_1337_logic.py
+++ b/game/game_1337_logic.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 class Game1337Logic:
     """Core logic for the 1337 betting game"""
 
+    # Highlight when #1 and #2 are within this many ms of each other.
+    CLOSE_RACE_THRESHOLD_MS = 1000
+    # Call out players whose bet was further than this from the win time.
+    FAR_OFF_THRESHOLD_MS = 30000
+
     def __init__(self, db_manager):
         self.db_manager = db_manager
         self._daily_win_times = {}  # Cache for daily win times: {date: datetime}
@@ -135,6 +140,19 @@ class Game1337Logic:
     def format_time_with_ms(self, dt: datetime) -> str:
         """Format datetime with milliseconds"""
         return dt.strftime("%H:%M:%S.%f")[:-3]
+
+    def format_offset(self, diff_ms: int) -> str:
+        """Format an offset to the win time compactly.
+
+        diff_ms is win_time - play_time in ms (positive = bet was before the
+        win time). Shows '-' for bets before the win time and '+' for bets
+        that overshot it: e.g. 570 -> '-570ms', 2400 -> '-2.4s', -1500 -> '+1.5s'.
+        """
+        sign = "-" if diff_ms >= 0 else "+"
+        magnitude = abs(diff_ms)
+        if magnitude < 1000:
+            return f"{sign}{magnitude}ms"
+        return f"{sign}{magnitude / 1000:.1f}s"
 
     def is_game_time_passed(self, current_time: Optional[datetime] = None) -> bool:
         """Check if the game time has passed (with 1 minute buffer)"""
@@ -632,6 +650,76 @@ class Game1337Logic:
 
         return embed_data
 
+    def _build_field_report(self, winner_data: Dict[str, Any]) -> List[str]:
+        """Build the 'top 3 / close race / way off' lines for the announcement.
+
+        Reads the day's bets, ranks the valid ones (≤ win time) by closeness,
+        flags a near-tie between #1 and #2, and calls out anyone whose bet was
+        more than FAR_OFF_THRESHOLD_MS from the win time.
+        """
+        win_time = winner_data["win_time"]
+        all_bets = self.get_daily_bets(win_time.date())
+        if not all_bets:
+            return []
+
+        lines: List[str] = []
+
+        # Top 3 valid bets: closest to (but not past) the win time wins, so the
+        # latest play_time that is still ≤ win_time is rank 1.
+        valid_bets = sorted(
+            (bet for bet in all_bets if bet["play_time"] <= win_time),
+            key=lambda bet: bet["play_time"],
+            reverse=True,
+        )
+        top_bets = valid_bets[:3]
+        shown_user_ids = {bet["user_id"] for bet in top_bets}
+
+        if top_bets:
+            medals = ["🥇", "🥈", "🥉"]
+            lines.append("")
+            lines.append("🏆 Top 3:")
+            for medal, bet in zip(medals, top_bets):
+                diff = self.calculate_millisecond_difference(bet["play_time"], win_time)
+                lines.append(
+                    f"{medal} {bet['username']} — "
+                    f"{self.format_time_with_ms(bet['play_time'])} "
+                    f"({self.format_offset(diff)})"
+                )
+
+        # Close-race callout between #1 and #2.
+        if len(valid_bets) >= 2:
+            gap = self.calculate_millisecond_difference(
+                valid_bets[1]["play_time"], valid_bets[0]["play_time"]
+            )
+            if 0 <= gap <= self.CLOSE_RACE_THRESHOLD_MS:
+                lines.append(f"⚡ Close race! Only {gap}ms between #1 and #2.")
+
+        # Way-off players: more than 30s from the win time, in either direction.
+        # Skip anyone already shown in the top 3 to avoid listing them twice.
+        far_off = sorted(
+            (
+                bet
+                for bet in all_bets
+                if bet["user_id"] not in shown_user_ids
+                and abs(
+                    self.calculate_millisecond_difference(bet["play_time"], win_time)
+                )
+                > self.FAR_OFF_THRESHOLD_MS
+            ),
+            key=lambda bet: abs(
+                self.calculate_millisecond_difference(bet["play_time"], win_time)
+            ),
+            reverse=True,
+        )
+        if far_off:
+            lines.append("")
+            lines.append("🛰️ Way off:")
+            for bet in far_off[:5]:
+                diff = self.calculate_millisecond_difference(bet["play_time"], win_time)
+                lines.append(f"• {bet['username']} ({self.format_offset(diff)})")
+
+        return lines
+
     def create_winner_message(
         self,
         winner_data: Dict[str, Any],
@@ -649,6 +737,9 @@ class Game1337Logic:
             f"Winners bet time: {self.format_time_with_ms(winner_data['play_time'])} - Win time: {self.format_time_with_ms(winner_data['win_time'])})",
             f"Performance: {winner_data['millisecond_diff']}ms before win time",
         ]
+
+        # Add the top 3 closest bets, a close-race callout, and far-off players
+        message_lines.extend(self._build_field_report(winner_data))
 
         # Add role assignments only if roles have actually changed
         if guild_id and current_role_holders:

--- a/tests/test_game_1337_logic.py
+++ b/tests/test_game_1337_logic.py
@@ -1125,5 +1125,109 @@ class TestGame1337Logic(unittest.TestCase):
         self.assertEqual(assignments["commander"], 789)
 
 
+class TestGame1337FieldReport(unittest.TestCase):
+    """Test the top-3 / close-race / way-off report in winner announcements"""
+
+    def setUp(self):
+        self.db_manager = Mock()
+        self.logic = Game1337Logic(self.db_manager)
+        self.win_time = datetime(2023, 12, 25, 13, 37, 42, 880000)
+
+    def _bet(self, user_id, username, play_time, bet_type="regular"):
+        return {
+            "user_id": user_id,
+            "username": username,
+            "play_time": play_time,
+            "bet_type": bet_type,
+            "server_id": 1,
+            "channel_id": 1,
+        }
+
+    def _winner_data(self, bet):
+        diff = self.logic.calculate_millisecond_difference(
+            bet["play_time"], self.win_time
+        )
+        return {**bet, "win_time": self.win_time, "millisecond_diff": diff}
+
+    def test_format_offset_before_and_after(self):
+        self.assertEqual(self.logic.format_offset(570), "-570ms")
+        self.assertEqual(self.logic.format_offset(2400), "-2.4s")
+        self.assertEqual(self.logic.format_offset(-1500), "+1.5s")
+        self.assertEqual(self.logic.format_offset(0), "-0ms")
+
+    def test_top_three_ranked_by_closeness(self):
+        bets = [
+            self._bet(1, "alice", datetime(2023, 12, 25, 13, 37, 42, 310000)),
+            self._bet(2, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000)),
+            self._bet(3, "carol", datetime(2023, 12, 25, 13, 37, 40, 500000)),
+            self._bet(4, "dave", datetime(2023, 12, 25, 13, 37, 41, 0)),
+        ]
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[1]))
+        report = "\n".join(lines)
+
+        self.assertIn("🏆 Top 3:", report)
+        self.assertIn("🥇 bob", report)
+        self.assertIn("🥈 alice", report)
+        self.assertIn("🥉 dave", report)
+        # carol is 4th-closest, not shown in the top 3
+        self.assertNotIn("carol", report)
+
+    def test_close_race_callout_within_threshold(self):
+        bets = [
+            self._bet(1, "alice", datetime(2023, 12, 25, 13, 37, 42, 310000)),
+            self._bet(2, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000)),
+        ]
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[1]))
+        self.assertTrue(any("Close race" in line for line in lines))
+        self.assertTrue(any("530ms" in line for line in lines))
+
+    def test_no_close_race_when_gap_large(self):
+        bets = [
+            self._bet(1, "alice", datetime(2023, 12, 25, 13, 37, 40, 0)),
+            self._bet(2, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000)),
+        ]
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[1]))
+        self.assertFalse(any("Close race" in line for line in lines))
+
+    def test_way_off_flags_both_directions(self):
+        bets = [
+            self._bet(2, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000)),
+            self._bet(1, "alice", datetime(2023, 12, 25, 13, 37, 42, 310000)),
+            self._bet(3, "carol", datetime(2023, 12, 25, 13, 37, 42, 0)),
+            # 37.9s too early — far enough back to fall outside the top 3
+            self._bet(4, "dave", datetime(2023, 12, 25, 13, 37, 5, 0)),
+            # overshot by 47.1s (invalid bet, but still "way off")
+            self._bet(5, "eve", datetime(2023, 12, 25, 13, 38, 30, 0), "early_bird"),
+        ]
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[0]))
+        report = "\n".join(lines)
+
+        self.assertIn("🛰️ Way off:", report)
+        self.assertIn("dave (-37.9s)", report)
+        self.assertIn("eve (+47.1s)", report)
+
+    def test_way_off_skips_users_shown_in_top_three(self):
+        # Only two players; dave is 37.9s early but is also the 2nd-closest
+        # valid bet, so he should appear in Top 3 and not be repeated.
+        bets = [
+            self._bet(2, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000)),
+            self._bet(4, "dave", datetime(2023, 12, 25, 13, 37, 5, 0)),
+        ]
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[0]))
+        self.assertFalse(any("Way off" in line for line in lines))
+
+    def test_empty_when_no_bets(self):
+        self.db_manager.get_daily_bets.return_value = []
+        winner = self._winner_data(
+            self._bet(2, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000))
+        )
+        self.assertEqual(self.logic._build_field_report(winner), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Enriches the daily 1337 winner announcement with extra context about the day's bets, as requested.

The announcement now looks like:

```
**bob** won with a regular bet
Winners bet time: 13:37:42.840 - Win time: 13:37:42.880)
Performance: 40ms before win time

🏆 Top 3:
🥇 bob — 13:37:42.840 (-40ms)
🥈 alice — 13:37:42.310 (-570ms)
🥉 carol — 13:37:40.500 (-2.4s)
⚡ Close race! Only 530ms between #1 and #2.

🛰️ Way off:
• eve (+47.1s)
• dave (-37.9s)
```

## What's new

- **Top 3** — the three valid bets (`≤ win time`) ranked by closeness, each with its offset to the win time.
- **Close race** — an extra `⚡` callout when #1 and #2 are within 1 second.
- **Way off** — flags anyone more than 30 seconds off the win time, in either direction (`-` = bet too early, `+` = overshot past the win time). Players already shown in the top 3 are not repeated; list is capped at 5.

## Notes

- Both thresholds are class constants on `Game1337Logic` (`CLOSE_RACE_THRESHOLD_MS = 1000`, `FAR_OFF_THRESHOLD_MS = 30000`) for easy tuning.
- Offsets are formatted compactly (`-570ms`, `-2.4s`) via a new `format_offset` helper.
- The top-3 ranking is by raw closeness to the win time, which in rare cases can differ from the rule-based winner (early-bird bets get a 3s handicap). Happy to align it with the winner-selection rules if preferred.

## Tests

Adds 7 tests covering ranking, the close-race threshold (on and off), both far-off directions, top-3 dedup, and the empty-bets case. All 1337 logic tests pass (67).