### PR TITLE
Add near-miss overshooter callout to 1337 winner announcement

### DIFF
--- a/game/game_1337_logic.py
+++ b/game/game_1337_logic.py
@@ -20,6 +20,8 @@ class Game1337Logic:
     CLOSE_RACE_THRESHOLD_MS = 1000
     # Call out players whose bet was further than this from the win time.
     FAR_OFF_THRESHOLD_MS = 30000
+    # Call out players who overshot the win time by no more than this.
+    OVERSHOOT_THRESHOLD_MS = 5000
 
     def __init__(self, db_manager):
         self.db_manager = db_manager
@@ -654,8 +656,9 @@ class Game1337Logic:
         """Build the 'top 3 / close race / way off' lines for the announcement.
 
         Reads the day's bets, ranks the valid ones (≤ win time) by closeness,
-        flags a near-tie between #1 and #2, and calls out anyone whose bet was
-        more than FAR_OFF_THRESHOLD_MS from the win time.
+        flags a near-tie between #1 and #2, calls out near-miss overshooters
+        (past the win time by at most OVERSHOOT_THRESHOLD_MS), and anyone
+        whose bet was more than FAR_OFF_THRESHOLD_MS from the win time.
         """
         win_time = winner_data["win_time"]
         all_bets = self.get_daily_bets(win_time.date())
@@ -693,6 +696,30 @@ class Game1337Logic:
             )
             if 0 <= gap <= self.CLOSE_RACE_THRESHOLD_MS:
                 lines.append(f"⚡ Close race! Only {gap}ms between #1 and #2.")
+
+        # Near-miss overshooters: past the win time (so their bet was invalid)
+        # but only just — the painful losses worth a shout-out.
+        overshooters = sorted(
+            (
+                bet
+                for bet in all_bets
+                if bet["play_time"] > win_time
+                and -self.calculate_millisecond_difference(bet["play_time"], win_time)
+                <= self.OVERSHOOT_THRESHOLD_MS
+            ),
+            key=lambda bet: bet["play_time"],
+        )
+        if overshooters:
+            shown_user_ids.update(bet["user_id"] for bet in overshooters[:3])
+            lines.append("")
+            lines.append("💥 So close, but too late:")
+            for bet in overshooters[:3]:
+                diff = self.calculate_millisecond_difference(bet["play_time"], win_time)
+                lines.append(
+                    f"• {bet['username']} — "
+                    f"{self.format_time_with_ms(bet['play_time'])} "
+                    f"({self.format_offset(diff)})"
+                )
 
         # Way-off players: more than 30s from the win time, in either direction.
         # Skip anyone already shown in the top 3 to avoid listing them twice.
@@ -738,7 +765,8 @@ class Game1337Logic:
             f"Performance: {winner_data['millisecond_diff']}ms before win time",
         ]
 
-        # Add the top 3 closest bets, a close-race callout, and far-off players
+        # Add the top 3 closest bets, a close-race callout, near-miss
+        # overshooters, and far-off players
         message_lines.extend(self._build_field_report(winner_data))
 
         # Add role assignments only if roles have actually changed

--- a/tests/test_game_1337_logic.py
+++ b/tests/test_game_1337_logic.py
@@ -1221,6 +1221,57 @@ class TestGame1337FieldReport(unittest.TestCase):
         lines = self.logic._build_field_report(self._winner_data(bets[0]))
         self.assertFalse(any("Way off" in line for line in lines))
 
+    def test_overshooters_within_threshold_are_called_out(self):
+        bets = [
+            self._bet(1, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000)),
+            # overshot by 120ms — the classic painful near-miss
+            self._bet(2, "alice", datetime(2023, 12, 25, 13, 37, 43, 0)),
+            # overshot by 2.12s — still within the 5s shout-out window
+            self._bet(3, "carol", datetime(2023, 12, 25, 13, 37, 45, 0)),
+            # overshot by 7.12s — past the threshold, not mentioned
+            self._bet(4, "dave", datetime(2023, 12, 25, 13, 37, 50, 0)),
+        ]
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[0]))
+        report = "\n".join(lines)
+
+        self.assertIn("💥 So close, but too late:", report)
+        self.assertIn("alice", report)
+        self.assertIn("(+120ms)", report)
+        self.assertIn("carol", report)
+        self.assertIn("(+2.1s)", report)
+        self.assertNotIn("dave", report)
+        # alice overshot by less than carol, so she is listed first
+        self.assertLess(report.index("alice"), report.index("carol"))
+
+    def test_no_overshoot_section_without_near_misses(self):
+        bets = [
+            self._bet(1, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000)),
+            self._bet(2, "alice", datetime(2023, 12, 25, 13, 37, 42, 310000)),
+        ]
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[0]))
+        self.assertFalse(any("too late" in line for line in lines))
+
+    def test_overshooters_capped_at_three(self):
+        bets = [self._bet(1, "bob", datetime(2023, 12, 25, 13, 37, 42, 840000))]
+        for i, name in enumerate(["alice", "carol", "dave", "eve"]):
+            bets.append(
+                self._bet(
+                    10 + i,
+                    name,
+                    datetime(2023, 12, 25, 13, 37, 43, i * 100000),
+                )
+            )
+        self.db_manager.get_daily_bets.return_value = bets
+        lines = self.logic._build_field_report(self._winner_data(bets[0]))
+        report = "\n".join(lines)
+
+        self.assertIn("alice", report)
+        self.assertIn("carol", report)
+        self.assertIn("dave", report)
+        self.assertNotIn("eve", report)
+
     def test_empty_when_no_bets(self):
         self.db_manager.get_daily_bets.return_value = []
         winner = self._winner_data(


### PR DESCRIPTION
## Summary
- Bets placed after the win time are invalid, so they never appeared in the Top 3 — and only got mentioned at all when more than 30s off ("Way off"). Players who missed the win time by a few hundred milliseconds got zero mention, even though those are exactly the near-misses worth calling out to keep players engaged.
- Adds a **💥 So close, but too late** section to the winner announcement, listing up to 3 players who overshot the win time by at most 5s (`OVERSHOOT_THRESHOLD_MS`), sorted by how narrowly they missed, with bet time and offset (e.g. `+220ms`).
- The section sits between the close-race callout and the "Way off" list.

Sample output:

```
🏆 Top 3:
🥇 bob — 13:37:42.840 (-40ms)
🥈 alice — 13:37:42.310 (-570ms)
⚡ Close race! Only 530ms between #1 and #2.

💥 So close, but too late:
• carol — 13:37:43.100 (+220ms)
• dave — 13:37:44.500 (+1.6s)

🛰️ Way off:
• eve (+47.1s)
```

## Test plan
- [x] New unit tests: callout ordering/formatting, section omitted when nobody narrowly overshot, 3-player cap
- [x] Full unittest suite (95 tests) and pytest e2e suite pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)