### PR TITLE
feat: change the /about command to also reply some useful runtime 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pyvenv.cfg
 .DS_Store
 
 venv/
+.aider*

--- a/commands/about_command.py
+++ b/commands/about_command.py
@@ -6,7 +6,7 @@ Shows bot information including build date, git revision, and branch.
 import logging
 import discord
 from discord.ext import commands
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import os
 
@@ -18,7 +18,7 @@ class AboutCommand(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(timezone.utc)
 
     @discord.app_commands.command(
         name="about", description="Show information about this bot"
@@ -128,7 +128,7 @@ class AboutCommand(commands.Cog):
 
     def _get_uptime(self):
         """Return human-friendly uptime string"""
-        delta = datetime.utcnow() - self.start_time
+        delta = datetime.now(timezone.utc) - self.start_time
         days = delta.days
         hours, remainder = divmod(delta.seconds, 3600)
         minutes, _ = divmod(remainder, 60)

--- a/commands/about_command.py
+++ b/commands/about_command.py
@@ -99,9 +99,7 @@ class AboutCommand(commands.Cog):
             guild_count = 0
 
         try:
-            member_count = sum(
-                getattr(g, "member_count", 0) for g in self.bot.guilds
-            )
+            member_count = sum(getattr(g, "member_count", 0) for g in self.bot.guilds)
         except Exception:
             member_count = 0
 

--- a/commands/about_command.py
+++ b/commands/about_command.py
@@ -18,6 +18,7 @@ class AboutCommand(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+        self.start_time = datetime.utcnow()
 
     @discord.app_commands.command(
         name="about", description="Show information about this bot"
@@ -76,8 +77,68 @@ class AboutCommand(commands.Cog):
             name="⚡ Status", value="✅ **Online and Running**", inline=False
         )
 
+        # ----- Runtime statistics (new) -----
+        try:
+            uptime = self._get_uptime()
+        except Exception:
+            uptime = "N/A"
+
+        try:
+            latency = self.bot.latency
+            if latency is not None:
+                latency_ms = round(latency * 1000)
+                latency_str = f"{latency_ms} ms"
+            else:
+                latency_str = "N/A"
+        except Exception:
+            latency_str = "N/A"
+
+        try:
+            guild_count = len(self.bot.guilds)
+        except Exception:
+            guild_count = 0
+
+        try:
+            member_count = sum(
+                getattr(g, "member_count", 0) for g in self.bot.guilds
+            )
+        except Exception:
+            member_count = 0
+
+        try:
+            command_count = len(self.bot.tree.get_commands())
+        except Exception:
+            command_count = 0
+
+        embed.add_field(
+            name="📊 Runtime Statistics",
+            value=(
+                f"**Uptime:** {uptime}\n"
+                f"**Latency:** {latency_str}\n"
+                f"**Servers:** {guild_count}\n"
+                f"**Members:** {member_count}\n"
+                f"**Commands:** {command_count}"
+            ),
+            inline=False,
+        )
+        # ------------------------------------
+
         embed.set_footer(text="Vibe Coding Discord Bot")
         return embed
+
+    def _get_uptime(self):
+        """Return human-friendly uptime string"""
+        delta = datetime.utcnow() - self.start_time
+        days = delta.days
+        hours, remainder = divmod(delta.seconds, 3600)
+        minutes, _ = divmod(remainder, 60)
+        parts = []
+        if days > 0:
+            parts.append(f"{days} day{'s' if days != 1 else ''}")
+        if hours > 0 or days > 0:
+            parts.append(f"{hours} hour{'s' if hours != 1 else ''}")
+        parts.append(f"{minutes} minute{'s' if minutes != 1 else ''}")
+        return " ".join(parts) if parts else "0 minutes"
 
     def _get_build_info(self):
         """Get build information from build-info.json file"""

--- a/tests/test_about_runtime_stats.py
+++ b/tests/test_about_runtime_stats.py
@@ -1,0 +1,65 @@
+import asyncio
+import datetime
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+import discord
+
+from commands.about_command import AboutCommand
+
+
+class TestAboutRuntimeStats(unittest.TestCase):
+    def test_about_includes_runtime_stats(self):
+        async def async_test():
+            bot = MagicMock()
+            bot.latency = 0.2  # seconds
+            guild1 = MagicMock()
+            guild1.member_count = 15
+            guild2 = MagicMock()
+            guild2.member_count = 5
+            bot.guilds = [guild1, guild2]
+            dummy_cmds = [MagicMock() for _ in range(8)]
+            bot.tree.get_commands.return_value = dummy_cmds
+
+            cog = AboutCommand(bot)
+            # Override start_time to a fixed past so we can assert uptime presence
+            cog.start_time = datetime.datetime(2025, 1, 1, 10, 0, 0)
+
+            interaction = MagicMock()
+            interaction.response.send_message = AsyncMock()
+
+            with patch.object(AboutCommand, "_get_build_info", return_value={
+                "build_time": "2025-01-01",
+                "git_branch": "dev",
+                "git_revision": "abc123",
+            }):
+                await cog.about(interaction)
+
+            send_msg_mock = interaction.response.send_message
+            send_msg_mock.assert_called_once()
+
+            # retrieve the embed passed to send_message
+            _, kwargs = send_msg_mock.call_args
+            embed = kwargs.get("embed")
+            self.assertIsNotNone(embed, "Embed not passed to send_message")
+
+            # locate the Runtime Statistics field
+            runtime_field = None
+            for field in embed.fields:
+                if "Runtime Statistics" in field.name:
+                    runtime_field = field
+                    break
+            self.assertIsNotNone(runtime_field, "Runtime Statistics field missing")
+
+            field_text = runtime_field.value
+            # uptime value is dynamic, so we only check the label exists
+            self.assertIn("Uptime:", field_text)
+            self.assertIn("Latency: 200 ms", field_text)
+            self.assertIn("Servers: 2", field_text)
+            self.assertIn("Members: 20", field_text)
+            self.assertIn("Commands: 8", field_text)
+
+        asyncio.run(async_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_about_runtime_stats.py
+++ b/tests/test_about_runtime_stats.py
@@ -32,7 +32,8 @@ class TestAboutRuntimeStats(unittest.TestCase):
                 "git_branch": "dev",
                 "git_revision": "abc123",
             }):
-                await cog.about(interaction)
+                # call the underlying slash command callback
+                await cog.about.callback(cog, interaction)
 
             send_msg_mock = interaction.response.send_message
             send_msg_mock.assert_called_once()

--- a/tests/test_about_runtime_stats.py
+++ b/tests/test_about_runtime_stats.py
@@ -22,16 +22,22 @@ class TestAboutRuntimeStats(unittest.TestCase):
 
             cog = AboutCommand(bot)
             # Override start_time to a fixed past so we can assert uptime presence
-            cog.start_time = datetime.datetime(2025, 1, 1, 10, 0, 0)
+            cog.start_time = datetime.datetime(
+                2025, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+            )
 
             interaction = MagicMock()
             interaction.response.send_message = AsyncMock()
 
-            with patch.object(AboutCommand, "_get_build_info", return_value={
-                "build_time": "2025-01-01",
-                "git_branch": "dev",
-                "git_revision": "abc123",
-            }):
+            with patch.object(
+                AboutCommand,
+                "_get_build_info",
+                return_value={
+                    "build_time": "2025-01-01",
+                    "git_branch": "dev",
+                    "git_revision": "abc123",
+                },
+            ):
                 # call the underlying slash command callback
                 await cog.about.callback(cog, interaction)
 
@@ -52,12 +58,12 @@ class TestAboutRuntimeStats(unittest.TestCase):
             self.assertIsNotNone(runtime_field, "Runtime Statistics field missing")
 
             field_text = runtime_field.value
-            # uptime value is dynamic, so we only check the label exists
-            self.assertIn("Uptime:", field_text)
-            self.assertIn("Latency: 200 ms", field_text)
-            self.assertIn("Servers: 2", field_text)
-            self.assertIn("Members: 20", field_text)
-            self.assertIn("Commands: 8", field_text)
+            # Check that all expected labels and values appear
+            self.assertIn("**Uptime:**", field_text)
+            self.assertIn("**Latency:** 200 ms", field_text)
+            self.assertIn("**Servers:** 2", field_text)
+            self.assertIn("**Members:** 20", field_text)
+            self.assertIn("**Commands:** 8", field_text)
 
         asyncio.run(async_test())
 

--- a/tests/test_about_runtime_stats.py
+++ b/tests/test_about_runtime_stats.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
-import discord
 
 from commands.about_command import AboutCommand
 


### PR DESCRIPTION
Automated change created by the /vibecode Discord command.

Feature request:

change the /about command to also reply some useful runtime stats

Implemented by aider + deepseek/deepseek-v4-pro. Test suite and ruff verified in the worker before this PR was opened.