### PR TITLE
feat: ich hätte gerne ein Feature, in dem ich mir die letzten Nach

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,6 @@ POSTILLON_LEASE_SECONDS=1800
 # Birthday greeting configuration
 # Channel where birthday greetings are posted (uses announcement channel if not set)
 BIRTHDAY_CHANNEL_ID=
+
+# TL;DR Message Summarization
+TLDR_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -63,5 +63,7 @@ POSTILLON_LEASE_SECONDS=1800
 # Channel where birthday greetings are posted (uses announcement channel if not set)
 BIRTHDAY_CHANNEL_ID=
 
-# TL;DR Message Summarization
+# TL;DR Message Summarization (uses DeepSeek via DEEPSEEK_API_KEY above)
 TLDR_ENABLED=true
+TLDR_MODEL=deepseek-chat
+DEEPSEEK_BASE_URL=https://api.deepseek.com

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ DEEPSEEK_BASE_URL=https://api.deepseek.com
 - `/tldr_optin`: Allow your own messages to be included in summaries (they are otherwise never sent to the AI)
 - `/tldr_optout`: Exclude your messages again (this is the default)
 
+On Kubernetes, enable the feature via the Helm chart's `tldr.enabled` value (default `true`); it injects `TLDR_ENABLED` and the shared `DEEPSEEK_API_KEY` (from the sealed secret) into the deployment. `TLDR_MODEL` and `DEEPSEEK_BASE_URL` are set in `helm/values.yaml`'s `env` block.
+
 **Privacy:** `/tldr` is opt-in only. Messages are sent to DeepSeek to generate the summary, but only messages from users who have run `/tldr_optin` ever leave Discord — bot messages and messages from everyone else are filtered out first.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ DEEPSEEK_BASE_URL=https://api.deepseek.com
 ```
 
 **Available Commands:**
-- `/tldr [anzahl] [zeit]`: Summarize recent channel messages (default: last 50; `zeit` optionally restricts to the last hour or 24 hours)
+- `/tldr [anzahl] [zeit]`: Summarize recent channel messages (works in text channels and threads). `anzahl` (5–200, default 50) is how many recent messages are **scanned**; the summary itself only covers those from opted-in users, so it may contain fewer. `zeit` optionally restricts to the last hour or 24 hours.
 - `/tldr_optin`: Allow your own messages to be included in summaries (they are otherwise never sent to the AI)
 - `/tldr_optout`: Exclude your messages again (this is the default)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A professional Discord bot written in Python 3.12 that responds to greetings wit
 - **Daily Statistics**: `/greetings` slash command shows daily greeting statistics
 - **AI-Powered Internet Troll**: Automatically analyzes longer messages (>100 chars) with configurable probability and acts as a humorous contrarian troll via ChatGPT API (requires user opt-in)
 - **Reaction-Based Fact Checking**: Users can react with 🔍 emoji to any message to request a detailed fact-check with numerical scoring (0-9 scale)
+- **TL;DR Summaries**: `/tldr` summarizes the recent messages of a channel via DeepSeek (optionally scoped to the last N messages or the last hour / 24 hours); users can exclude their own messages with `/tldr_optout` (and re-enable with `/tldr_optin`)
 - **Vibecode (self-extending bot)**: `/vibecode` spawns a Kubernetes Job in which an agentic coding AI (Claude Code + DeepSeek) implements the requested feature in this repository, verifies it with the test suite and ruff, opens a pull request, and works through the AI reviewer's findings until it is approved
 - **Postillon RSS archive**: Polls for new Postillon articles every 15 minutes, stores them in MariaDB, and publishes new entries as Discord embeds
 - **Birthday greetings**: `/birthday-set` stores a birthday, and the bot congratulates the user at 08:00 (Europe/Berlin) with a randomly varied message
@@ -184,6 +185,25 @@ The bot also features a reaction-based fact-checking system that allows users to
 - Comprehensive error handling and user feedback
 - Statistical tracking for monitoring usage
 - Same privacy protection as klugscheißer feature
+
+### TL;DR Configuration
+
+Enable the `/tldr` summary command (uses DeepSeek):
+
+```bash
+# TL;DR Configuration (optional)
+TLDR_ENABLED=true
+DEEPSEEK_API_KEY=your_deepseek_api_key_here   # shared with /vibecode
+TLDR_MODEL=deepseek-chat
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+```
+
+**Available Commands:**
+- `/tldr [anzahl] [zeit]`: Summarize recent channel messages (default: last 50; `zeit` optionally restricts to the last hour or 24 hours)
+- `/tldr_optout`: Exclude your own messages from summaries (they are never sent to the AI)
+- `/tldr_optin`: Re-include your messages
+
+**Privacy:** Messages are sent to DeepSeek to generate the summary. Bot messages and messages from opted-out users are filtered out before anything leaves Discord.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -200,12 +200,12 @@ DEEPSEEK_BASE_URL=https://api.deepseek.com
 
 **Available Commands:**
 - `/tldr [anzahl] [zeit]`: Summarize recent channel messages (works in text channels and threads). `anzahl` (5–200, default 50) is how many recent messages are **scanned**; the summary itself only covers those from opted-in users, so it may contain fewer. `zeit` optionally restricts to the last hour or 24 hours.
-- `/tldr_optin`: Allow your own messages to be included in summaries (they are otherwise never sent to the AI)
-- `/tldr_optout`: Exclude your messages again (this is the default)
+- `/tldr_optin`: Allow your own messages to be included in summaries (they are otherwise never sent to the AI). The opt-in applies only to the server you run it on.
+- `/tldr_optout`: Exclude your messages again on this server (this is the default)
 
 On Kubernetes, enable the feature via the Helm chart's `tldr.enabled` value (default `true`); it injects `TLDR_ENABLED` and the shared `DEEPSEEK_API_KEY` (from the sealed secret) into the deployment. `TLDR_MODEL` and `DEEPSEEK_BASE_URL` are set in `helm/values.yaml`'s `env` block.
 
-**Privacy:** `/tldr` is opt-in only. Messages are sent to DeepSeek to generate the summary, but only messages from users who have run `/tldr_optin` ever leave Discord — bot messages and messages from everyone else are filtered out first.
+**Privacy:** `/tldr` is opt-in only. Messages are sent to DeepSeek to generate the summary, but only messages from users who have run `/tldr_optin` ever leave Discord — bot messages and messages from everyone else are filtered out first. Consent is stored per server, so opting in on one server never makes your messages summarizable on another.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A professional Discord bot written in Python 3.12 that responds to greetings wit
 - **Daily Statistics**: `/greetings` slash command shows daily greeting statistics
 - **AI-Powered Internet Troll**: Automatically analyzes longer messages (>100 chars) with configurable probability and acts as a humorous contrarian troll via ChatGPT API (requires user opt-in)
 - **Reaction-Based Fact Checking**: Users can react with 🔍 emoji to any message to request a detailed fact-check with numerical scoring (0-9 scale)
-- **TL;DR Summaries**: `/tldr` summarizes the recent messages of a channel via DeepSeek (optionally scoped to the last N messages or the last hour / 24 hours); users can exclude their own messages with `/tldr_optout` (and re-enable with `/tldr_optin`)
+- **TL;DR Summaries**: `/tldr` summarizes the recent messages of a channel via DeepSeek (optionally scoped to the last N messages or the last hour / 24 hours); opt-in only — only messages from users who ran `/tldr_optin` are summarized (revert with `/tldr_optout`)
 - **Vibecode (self-extending bot)**: `/vibecode` spawns a Kubernetes Job in which an agentic coding AI (Claude Code + DeepSeek) implements the requested feature in this repository, verifies it with the test suite and ruff, opens a pull request, and works through the AI reviewer's findings until it is approved
 - **Postillon RSS archive**: Polls for new Postillon articles every 15 minutes, stores them in MariaDB, and publishes new entries as Discord embeds
 - **Birthday greetings**: `/birthday-set` stores a birthday, and the bot congratulates the user at 08:00 (Europe/Berlin) with a randomly varied message
@@ -200,10 +200,10 @@ DEEPSEEK_BASE_URL=https://api.deepseek.com
 
 **Available Commands:**
 - `/tldr [anzahl] [zeit]`: Summarize recent channel messages (default: last 50; `zeit` optionally restricts to the last hour or 24 hours)
-- `/tldr_optout`: Exclude your own messages from summaries (they are never sent to the AI)
-- `/tldr_optin`: Re-include your messages
+- `/tldr_optin`: Allow your own messages to be included in summaries (they are otherwise never sent to the AI)
+- `/tldr_optout`: Exclude your messages again (this is the default)
 
-**Privacy:** Messages are sent to DeepSeek to generate the summary. Bot messages and messages from opted-out users are filtered out before anything leaves Discord.
+**Privacy:** `/tldr` is opt-in only. Messages are sent to DeepSeek to generate the summary, but only messages from users who have run `/tldr_optin` ever leave Discord — bot messages and messages from everyone else are filtered out first.
 
 ## Usage
 

--- a/commands/tldr_command.py
+++ b/commands/tldr_command.py
@@ -3,6 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 import logging
 from datetime import timedelta
+from typing import Optional
 import openai
 
 from config import Config
@@ -15,7 +16,11 @@ class TldrCommand(commands.Cog):
 
     def __init__(self, bot, db_manager):
         self.bot = bot
-        self.openai_client = openai.AsyncOpenAI(api_key=Config.OPENAI_API_KEY)
+        self.db_manager = db_manager
+        self.ai_client = openai.AsyncOpenAI(
+            api_key=Config.DEEPSEEK_API_KEY,
+            base_url=Config.DEEPSEEK_BASE_URL,
+        )
 
     @app_commands.command(
         name="tldr",
@@ -31,14 +36,14 @@ class TldrCommand(commands.Cog):
         self,
         interaction: discord.Interaction,
         anzahl: int = 50,
-        zeit: str = None,
+        zeit: Optional[str] = None,
     ):
         """Summarize recent messages of this channel."""
         await interaction.response.defer(ephemeral=False)
 
-        if not Config.OPENAI_API_KEY:
+        if not Config.DEEPSEEK_API_KEY:
             await interaction.followup.send(
-                "❌ OpenAI API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
+                "❌ DeepSeek API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
                 ephemeral=True,
             )
             return
@@ -59,9 +64,19 @@ class TldrCommand(commands.Cog):
             after = discord.utils.utcnow() - timedelta(hours=24)
 
         try:
+            opted_out = self.db_manager.get_tldr_opted_out_users()
+
             messages = []
-            async for msg in channel.history(limit=limit, after=after):
+            skipped_optout = 0
+            # Always fetch newest-first so a limit keeps the *most recent*
+            # messages (also relevant when `after` is set for time windows).
+            async for msg in channel.history(
+                limit=limit, after=after, oldest_first=False
+            ):
                 if msg.author.bot:
+                    continue
+                if msg.author.id in opted_out:
+                    skipped_optout += 1
                     continue
                 messages.append(msg)
 
@@ -72,11 +87,13 @@ class TldrCommand(commands.Cog):
                 )
                 return
 
-            # Build a combined text to send to OpenAI
+            # Build a combined text to send to the AI. History is newest-first,
+            # so reverse it to give the model chronological order.
             lines = []
             total_chars = 0
             max_chars = 3000
-            for msg in messages:
+            used_messages = 0
+            for msg in reversed(messages):
                 author = msg.author.display_name
                 content = msg.content[:200]  # truncate per message
                 line = f"{author}: {content}"
@@ -84,6 +101,7 @@ class TldrCommand(commands.Cog):
                     break
                 lines.append(line)
                 total_chars += len(line)
+                used_messages += 1
 
             combined = "\n".join(lines)
 
@@ -94,7 +112,10 @@ class TldrCommand(commands.Cog):
                 description=summary,
                 color=discord.Color.blue(),
             )
-            embed.set_footer(text=f"Basierend auf {len(messages)} Nachrichten")
+            footer = f"Basierend auf {used_messages} Nachrichten"
+            if skipped_optout:
+                footer += f" · {skipped_optout} ausgeschlossen (Opt-out)"
+            embed.set_footer(text=footer)
             await interaction.followup.send(embed=embed)
         except Exception as e:
             logger.error(f"Fehler im tldr-Befehl: {e}", exc_info=True)
@@ -103,11 +124,51 @@ class TldrCommand(commands.Cog):
                 ephemeral=True,
             )
 
+    @app_commands.command(
+        name="tldr_optout",
+        description="Schließe deine Nachrichten von /tldr-Zusammenfassungen aus.",
+    )
+    async def tldr_optout(self, interaction: discord.Interaction):
+        """Exclude the invoking user's messages from future /tldr summaries."""
+        ok = self.db_manager.set_tldr_optout(interaction.user.id, True)
+        if ok:
+            await interaction.response.send_message(
+                "🔕 Deine Nachrichten werden ab jetzt aus /tldr-Zusammenfassungen "
+                "ausgeschlossen und nicht mehr an die KI gesendet. "
+                "Mit `/tldr_optin` kannst du das rückgängig machen.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "⚠️ Deine Einstellung konnte nicht gespeichert werden. "
+                "Bitte später erneut versuchen.",
+                ephemeral=True,
+            )
+
+    @app_commands.command(
+        name="tldr_optin",
+        description="Erlaube wieder, dass deine Nachrichten in /tldr zusammengefasst werden.",
+    )
+    async def tldr_optin(self, interaction: discord.Interaction):
+        """Re-include the invoking user's messages in /tldr summaries."""
+        ok = self.db_manager.set_tldr_optout(interaction.user.id, False)
+        if ok:
+            await interaction.response.send_message(
+                "🔔 Deine Nachrichten können wieder in /tldr-Zusammenfassungen einfließen.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "⚠️ Deine Einstellung konnte nicht gespeichert werden. "
+                "Bitte später erneut versuchen.",
+                ephemeral=True,
+            )
+
     async def _summarize(self, context: str) -> str:
-        """Use OpenAI to summarize the given context in German bullet points."""
+        """Use DeepSeek to summarize the given context in German bullet points."""
         try:
-            response = await self.openai_client.chat.completions.create(
-                model="gpt-3.5-turbo",
+            response = await self.ai_client.chat.completions.create(
+                model=Config.TLDR_MODEL,
                 messages=[
                     {
                         "role": "system",
@@ -124,10 +185,11 @@ class TldrCommand(commands.Cog):
                 ],
                 max_tokens=500,
                 temperature=0.5,
+                timeout=30,
             )
             return response.choices[0].message.content.strip()
         except Exception as e:
-            logger.error(f"OpenAI-Summarization failed: {e}")
+            logger.error(f"DeepSeek summarization failed: {e}")
             raise
 
 

--- a/commands/tldr_command.py
+++ b/commands/tldr_command.py
@@ -70,7 +70,9 @@ class TldrCommand(commands.Cog):
             after = discord.utils.utcnow() - timedelta(hours=24)
 
         try:
-            opted_in = self.db_manager.get_tldr_opted_in_users()
+            # Opt-in is per guild: consent given on another server must not
+            # leak messages into this one's summaries.
+            opted_in = self.db_manager.get_tldr_opted_in_users(interaction.guild_id)
 
             messages = []
             skipped_no_optin = 0
@@ -152,14 +154,24 @@ class TldrCommand(commands.Cog):
         """Include the invoking user's messages in future /tldr summaries.
 
         /tldr is opt-in only, so nothing of a user's is summarized until they
-        run this command.
+        run this command. Consent applies only to the server it was given on.
         """
-        ok = self.db_manager.set_tldr_optin(interaction.user.id, True)
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "❌ Dieser Befehl funktioniert nur auf einem Server, da das "
+                "Opt-in pro Server gilt.",
+                ephemeral=True,
+            )
+            return
+
+        ok = self.db_manager.set_tldr_optin(
+            interaction.guild_id, interaction.user.id, True
+        )
         if ok:
             await interaction.response.send_message(
-                "🔔 Deine Nachrichten können ab jetzt in /tldr-Zusammenfassungen "
-                "einfließen und werden dafür an die KI gesendet. "
-                "Mit `/tldr_optout` kannst du das wieder rückgängig machen.",
+                "🔔 Deine Nachrichten können ab jetzt auf diesem Server in "
+                "/tldr-Zusammenfassungen einfließen und werden dafür an die KI "
+                "gesendet. Mit `/tldr_optout` kannst du das wieder rückgängig machen.",
                 ephemeral=True,
             )
         else:
@@ -177,13 +189,24 @@ class TldrCommand(commands.Cog):
         """Exclude the invoking user's messages from /tldr summaries again.
 
         This is the default state; the command exists to undo a prior
-        /tldr_optin.
+        /tldr_optin on this server.
         """
-        ok = self.db_manager.set_tldr_optin(interaction.user.id, False)
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "❌ Dieser Befehl funktioniert nur auf einem Server, da das "
+                "Opt-in pro Server gilt.",
+                ephemeral=True,
+            )
+            return
+
+        ok = self.db_manager.set_tldr_optin(
+            interaction.guild_id, interaction.user.id, False
+        )
         if ok:
             await interaction.response.send_message(
-                "🔕 Deine Nachrichten werden aus /tldr-Zusammenfassungen "
-                "ausgeschlossen und nicht mehr an die KI gesendet.",
+                "🔕 Deine Nachrichten werden auf diesem Server aus "
+                "/tldr-Zusammenfassungen ausgeschlossen und nicht mehr an die "
+                "KI gesendet.",
                 ephemeral=True,
             )
         else:

--- a/commands/tldr_command.py
+++ b/commands/tldr_command.py
@@ -26,6 +26,10 @@ class TldrCommand(commands.Cog):
         name="tldr",
         description="Fasse die letzten Nachrichten dieses Channels zusammen.",
     )
+    @app_commands.describe(
+        anzahl="Wie viele der letzten Nachrichten durchsucht werden (5–200)",
+        zeit="Optional auf die letzte Stunde oder 24 Stunden beschränken",
+    )
     @app_commands.choices(
         zeit=[
             app_commands.Choice(name="Letzte Stunde", value="1h"),
@@ -35,26 +39,28 @@ class TldrCommand(commands.Cog):
     async def tldr(
         self,
         interaction: discord.Interaction,
-        anzahl: int = 50,
+        anzahl: app_commands.Range[int, 5, 200] = 50,
         zeit: Optional[str] = None,
     ):
         """Summarize recent messages of this channel."""
-        await interaction.response.defer(ephemeral=False)
-
+        # Validate synchronously first so these errors stay private; only
+        # defer (which posts a public placeholder) once we know we'll work.
         if not Config.DEEPSEEK_API_KEY:
-            await interaction.followup.send(
+            await interaction.response.send_message(
                 "❌ DeepSeek API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
                 ephemeral=True,
             )
             return
 
         channel = interaction.channel
-        if not isinstance(channel, discord.TextChannel):
-            await interaction.followup.send(
+        if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+            await interaction.response.send_message(
                 "❌ Dieser Befehl funktioniert nur in Textkanälen.",
                 ephemeral=True,
             )
             return
+
+        await interaction.response.defer(ephemeral=False)
 
         limit = max(5, min(anzahl, 200))
         after = None
@@ -74,6 +80,9 @@ class TldrCommand(commands.Cog):
                 limit=limit, after=after, oldest_first=False
             ):
                 if msg.author.bot:
+                    continue
+                # Nothing to summarize for attachment-/embed-/sticker-only posts.
+                if not msg.content.strip():
                     continue
                 # /tldr is opt-in only: skip anyone who hasn't explicitly
                 # opted in to having their messages summarized.
@@ -207,7 +216,11 @@ class TldrCommand(commands.Cog):
                 temperature=0.5,
                 timeout=30,
             )
-            return response.choices[0].message.content.strip()
+            if response.choices and response.choices[0].message:
+                content = response.choices[0].message.content
+                if content:
+                    return content.strip()
+            raise ValueError("DeepSeek returned an empty summary")
         except Exception as e:
             logger.error(f"DeepSeek summarization failed: {e}")
             raise

--- a/commands/tldr_command.py
+++ b/commands/tldr_command.py
@@ -94,9 +94,7 @@ class TldrCommand(commands.Cog):
                 description=summary,
                 color=discord.Color.blue(),
             )
-            embed.set_footer(
-                text=f"Basierend auf {len(messages)} Nachrichten"
-            )
+            embed.set_footer(text=f"Basierend auf {len(messages)} Nachrichten")
             await interaction.followup.send(embed=embed)
         except Exception as e:
             logger.error(f"Fehler im tldr-Befehl: {e}", exc_info=True)

--- a/commands/tldr_command.py
+++ b/commands/tldr_command.py
@@ -64,10 +64,10 @@ class TldrCommand(commands.Cog):
             after = discord.utils.utcnow() - timedelta(hours=24)
 
         try:
-            opted_out = self.db_manager.get_tldr_opted_out_users()
+            opted_in = self.db_manager.get_tldr_opted_in_users()
 
             messages = []
-            skipped_optout = 0
+            skipped_no_optin = 0
             # Always fetch newest-first so a limit keeps the *most recent*
             # messages (also relevant when `after` is set for time windows).
             async for msg in channel.history(
@@ -75,16 +75,27 @@ class TldrCommand(commands.Cog):
             ):
                 if msg.author.bot:
                     continue
-                if msg.author.id in opted_out:
-                    skipped_optout += 1
+                # /tldr is opt-in only: skip anyone who hasn't explicitly
+                # opted in to having their messages summarized.
+                if msg.author.id not in opted_in:
+                    skipped_no_optin += 1
                     continue
                 messages.append(msg)
 
             if not messages:
-                await interaction.followup.send(
-                    "Keine Nachrichten gefunden, die zusammengefasst werden können.",
-                    ephemeral=True,
-                )
+                if skipped_no_optin:
+                    await interaction.followup.send(
+                        "Keine Nachrichten zum Zusammenfassen: Niemand mit "
+                        "Nachrichten in diesem Zeitraum hat `/tldr_optin` "
+                        "aktiviert. Nur Nachrichten von Nutzern mit Opt-in "
+                        "werden zusammengefasst.",
+                        ephemeral=True,
+                    )
+                else:
+                    await interaction.followup.send(
+                        "Keine Nachrichten gefunden, die zusammengefasst werden können.",
+                        ephemeral=True,
+                    )
                 return
 
             # Build a combined text to send to the AI. History is newest-first,
@@ -113,8 +124,8 @@ class TldrCommand(commands.Cog):
                 color=discord.Color.blue(),
             )
             footer = f"Basierend auf {used_messages} Nachrichten"
-            if skipped_optout:
-                footer += f" · {skipped_optout} ausgeschlossen (Opt-out)"
+            if skipped_no_optin:
+                footer += f" · {skipped_no_optin} ausgeschlossen (kein Opt-in)"
             embed.set_footer(text=footer)
             await interaction.followup.send(embed=embed)
         except Exception as e:
@@ -125,17 +136,21 @@ class TldrCommand(commands.Cog):
             )
 
     @app_commands.command(
-        name="tldr_optout",
-        description="Schließe deine Nachrichten von /tldr-Zusammenfassungen aus.",
+        name="tldr_optin",
+        description="Erlaube, dass deine Nachrichten in /tldr zusammengefasst werden.",
     )
-    async def tldr_optout(self, interaction: discord.Interaction):
-        """Exclude the invoking user's messages from future /tldr summaries."""
-        ok = self.db_manager.set_tldr_optout(interaction.user.id, True)
+    async def tldr_optin(self, interaction: discord.Interaction):
+        """Include the invoking user's messages in future /tldr summaries.
+
+        /tldr is opt-in only, so nothing of a user's is summarized until they
+        run this command.
+        """
+        ok = self.db_manager.set_tldr_optin(interaction.user.id, True)
         if ok:
             await interaction.response.send_message(
-                "🔕 Deine Nachrichten werden ab jetzt aus /tldr-Zusammenfassungen "
-                "ausgeschlossen und nicht mehr an die KI gesendet. "
-                "Mit `/tldr_optin` kannst du das rückgängig machen.",
+                "🔔 Deine Nachrichten können ab jetzt in /tldr-Zusammenfassungen "
+                "einfließen und werden dafür an die KI gesendet. "
+                "Mit `/tldr_optout` kannst du das wieder rückgängig machen.",
                 ephemeral=True,
             )
         else:
@@ -146,15 +161,20 @@ class TldrCommand(commands.Cog):
             )
 
     @app_commands.command(
-        name="tldr_optin",
-        description="Erlaube wieder, dass deine Nachrichten in /tldr zusammengefasst werden.",
+        name="tldr_optout",
+        description="Schließe deine Nachrichten wieder von /tldr-Zusammenfassungen aus.",
     )
-    async def tldr_optin(self, interaction: discord.Interaction):
-        """Re-include the invoking user's messages in /tldr summaries."""
-        ok = self.db_manager.set_tldr_optout(interaction.user.id, False)
+    async def tldr_optout(self, interaction: discord.Interaction):
+        """Exclude the invoking user's messages from /tldr summaries again.
+
+        This is the default state; the command exists to undo a prior
+        /tldr_optin.
+        """
+        ok = self.db_manager.set_tldr_optin(interaction.user.id, False)
         if ok:
             await interaction.response.send_message(
-                "🔔 Deine Nachrichten können wieder in /tldr-Zusammenfassungen einfließen.",
+                "🔕 Deine Nachrichten werden aus /tldr-Zusammenfassungen "
+                "ausgeschlossen und nicht mehr an die KI gesendet.",
                 ephemeral=True,
             )
         else:

--- a/commands/tldr_command.py
+++ b/commands/tldr_command.py
@@ -1,0 +1,137 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+import logging
+from datetime import timedelta
+import openai
+
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class TldrCommand(commands.Cog):
+    """Slash command for summarizing recent channel messages."""
+
+    def __init__(self, bot, db_manager):
+        self.bot = bot
+        self.openai_client = openai.AsyncOpenAI(api_key=Config.OPENAI_API_KEY)
+
+    @app_commands.command(
+        name="tldr",
+        description="Fasse die letzten Nachrichten dieses Channels zusammen.",
+    )
+    @app_commands.choices(
+        zeit=[
+            app_commands.Choice(name="Letzte Stunde", value="1h"),
+            app_commands.Choice(name="Letzte 24 Stunden", value="24h"),
+        ],
+    )
+    async def tldr(
+        self,
+        interaction: discord.Interaction,
+        anzahl: int = 50,
+        zeit: str = None,
+    ):
+        """Summarize recent messages of this channel."""
+        await interaction.response.defer(ephemeral=False)
+
+        if not Config.OPENAI_API_KEY:
+            await interaction.followup.send(
+                "❌ OpenAI API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
+                ephemeral=True,
+            )
+            return
+
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.followup.send(
+                "❌ Dieser Befehl funktioniert nur in Textkanälen.",
+                ephemeral=True,
+            )
+            return
+
+        limit = max(5, min(anzahl, 200))
+        after = None
+        if zeit == "1h":
+            after = discord.utils.utcnow() - timedelta(hours=1)
+        elif zeit == "24h":
+            after = discord.utils.utcnow() - timedelta(hours=24)
+
+        try:
+            messages = []
+            async for msg in channel.history(limit=limit, after=after):
+                if msg.author.bot:
+                    continue
+                messages.append(msg)
+
+            if not messages:
+                await interaction.followup.send(
+                    "Keine Nachrichten gefunden, die zusammengefasst werden können.",
+                    ephemeral=True,
+                )
+                return
+
+            # Build a combined text to send to OpenAI
+            lines = []
+            total_chars = 0
+            max_chars = 3000
+            for msg in messages:
+                author = msg.author.display_name
+                content = msg.content[:200]  # truncate per message
+                line = f"{author}: {content}"
+                if total_chars + len(line) > max_chars:
+                    break
+                lines.append(line)
+                total_chars += len(line)
+
+            combined = "\n".join(lines)
+
+            summary = await self._summarize(combined)
+
+            embed = discord.Embed(
+                title="📝 TL;DR Zusammenfassung",
+                description=summary,
+                color=discord.Color.blue(),
+            )
+            embed.set_footer(
+                text=f"Basierend auf {len(messages)} Nachrichten"
+            )
+            await interaction.followup.send(embed=embed)
+        except Exception as e:
+            logger.error(f"Fehler im tldr-Befehl: {e}", exc_info=True)
+            await interaction.followup.send(
+                "⚠️ Beim Erstellen der Zusammenfassung ist ein Fehler aufgetreten.",
+                ephemeral=True,
+            )
+
+    async def _summarize(self, context: str) -> str:
+        """Use OpenAI to summarize the given context in German bullet points."""
+        try:
+            response = await self.openai_client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "Du bist ein KI-Assistent, der Chatverläufe in "
+                            "deutscher Sprache kurz und prägnant in Stichpunkten "
+                            "zusammenfasst. Verwende maximal 3-5 Aufzählungspunkte."
+                        ),
+                    },
+                    {
+                        "role": "user",
+                        "content": f"Fasse folgenden Chatverlauf zusammen:\n\n{context}",
+                    },
+                ],
+                max_tokens=500,
+                temperature=0.5,
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as e:
+            logger.error(f"OpenAI-Summarization failed: {e}")
+            raise
+
+
+async def setup(bot, db_manager):
+    await bot.add_cog(TldrCommand(bot, db_manager))

--- a/config.py
+++ b/config.py
@@ -114,8 +114,10 @@ class Config:
         else None
     )
 
-    # TL;DR Message Summarization
+    # TL;DR Message Summarization (uses DeepSeek via the DEEPSEEK_API_KEY)
     TLDR_ENABLED = os.getenv("TLDR_ENABLED", "false").lower() == "true"
+    TLDR_MODEL = os.getenv("TLDR_MODEL", "deepseek-chat")
+    DEEPSEEK_BASE_URL = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
 
 
 def setup_logging():

--- a/config.py
+++ b/config.py
@@ -114,6 +114,9 @@ class Config:
         else None
     )
 
+    # TL;DR Message Summarization
+    TLDR_ENABLED = os.getenv("TLDR_ENABLED", "false").lower() == "true"
+
 
 def setup_logging():
     logging.basicConfig(

--- a/database.py
+++ b/database.py
@@ -155,8 +155,10 @@ class DatabaseManager:
 
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS tldr_optins (
-                    user_id BIGINT PRIMARY KEY,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    guild_id BIGINT NOT NULL,
+                    user_id BIGINT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (guild_id, user_id)
                 )
             """)
 
@@ -1103,11 +1105,12 @@ class DatabaseManager:
             if connection:
                 connection.close()
 
-    def set_tldr_optin(self, user_id, opted_in):
+    def set_tldr_optin(self, guild_id, user_id, opted_in):
         """Opt a user in to (or back out of) having their messages summarized by /tldr.
 
         /tldr is opt-in only: a user's messages are excluded from summaries
-        unless they have an explicit opt-in row here.
+        unless they have an explicit opt-in row here. Consent is per guild, so
+        opting in on one server never exposes the user's messages on another.
         """
         connection = None
         try:
@@ -1116,21 +1119,23 @@ class DatabaseManager:
             if opted_in:
                 cursor.execute(
                     """
-                    INSERT INTO tldr_optins (user_id)
-                    VALUES (?)
+                    INSERT INTO tldr_optins (guild_id, user_id)
+                    VALUES (?, ?)
                     ON DUPLICATE KEY UPDATE user_id = user_id
                 """,
-                    (user_id,),
+                    (guild_id, user_id),
                 )
             else:
                 cursor.execute(
-                    "DELETE FROM tldr_optins WHERE user_id = ?",
-                    (user_id,),
+                    "DELETE FROM tldr_optins WHERE guild_id = ? AND user_id = ?",
+                    (guild_id, user_id),
                 )
 
             connection.commit()
             status = "opted in to" if opted_in else "opted back out of"
-            logger.info(f"User {user_id} {status} /tldr summarization")
+            logger.info(
+                f"User {user_id} {status} /tldr summarization in guild {guild_id}"
+            )
             return True
         except mariadb.Error as e:
             logger.error(f"Error setting tldr opt-in: {e}")
@@ -1139,13 +1144,16 @@ class DatabaseManager:
             if connection:
                 connection.close()
 
-    def get_tldr_opted_in_users(self):
-        """Return the set of user_ids that have opted in to /tldr summarization."""
+    def get_tldr_opted_in_users(self, guild_id):
+        """Return the set of user_ids opted in to /tldr summarization in this guild."""
         connection = None
         try:
             connection = self._get_connection()
             cursor = connection.cursor()
-            cursor.execute("SELECT user_id FROM tldr_optins")
+            cursor.execute(
+                "SELECT user_id FROM tldr_optins WHERE guild_id = ?",
+                (guild_id,),
+            )
             return {row[0] for row in cursor.fetchall()}
         except mariadb.Error as e:
             logger.error(f"Error fetching tldr opt-in list: {e}")

--- a/database.py
+++ b/database.py
@@ -154,7 +154,7 @@ class DatabaseManager:
             """)
 
             cursor.execute("""
-                CREATE TABLE IF NOT EXISTS tldr_optouts (
+                CREATE TABLE IF NOT EXISTS tldr_optins (
                     user_id BIGINT PRIMARY KEY,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
@@ -1103,16 +1103,20 @@ class DatabaseManager:
             if connection:
                 connection.close()
 
-    def set_tldr_optout(self, user_id, opted_out):
-        """Opt a user out of (or back into) having their messages summarized by /tldr."""
+    def set_tldr_optin(self, user_id, opted_in):
+        """Opt a user in to (or back out of) having their messages summarized by /tldr.
+
+        /tldr is opt-in only: a user's messages are excluded from summaries
+        unless they have an explicit opt-in row here.
+        """
         connection = None
         try:
             connection = self._get_connection()
             cursor = connection.cursor()
-            if opted_out:
+            if opted_in:
                 cursor.execute(
                     """
-                    INSERT INTO tldr_optouts (user_id)
+                    INSERT INTO tldr_optins (user_id)
                     VALUES (?)
                     ON DUPLICATE KEY UPDATE user_id = user_id
                 """,
@@ -1120,49 +1124,49 @@ class DatabaseManager:
                 )
             else:
                 cursor.execute(
-                    "DELETE FROM tldr_optouts WHERE user_id = ?",
+                    "DELETE FROM tldr_optins WHERE user_id = ?",
                     (user_id,),
                 )
 
             connection.commit()
-            status = "opted out of" if opted_out else "opted back into"
+            status = "opted in to" if opted_in else "opted back out of"
             logger.info(f"User {user_id} {status} /tldr summarization")
             return True
         except mariadb.Error as e:
-            logger.error(f"Error setting tldr opt-out: {e}")
+            logger.error(f"Error setting tldr opt-in: {e}")
             return False
         finally:
             if connection:
                 connection.close()
 
-    def is_tldr_opted_out(self, user_id):
-        """Return True if the user has opted out of /tldr summarization."""
+    def is_tldr_opted_in(self, user_id):
+        """Return True if the user has opted in to /tldr summarization."""
         connection = None
         try:
             connection = self._get_connection()
             cursor = connection.cursor()
             cursor.execute(
-                "SELECT 1 FROM tldr_optouts WHERE user_id = ?",
+                "SELECT 1 FROM tldr_optins WHERE user_id = ?",
                 (user_id,),
             )
             return cursor.fetchone() is not None
         except mariadb.Error as e:
-            logger.error(f"Error fetching tldr opt-out: {e}")
+            logger.error(f"Error fetching tldr opt-in: {e}")
             return False
         finally:
             if connection:
                 connection.close()
 
-    def get_tldr_opted_out_users(self):
-        """Return the set of user_ids that have opted out of /tldr summarization."""
+    def get_tldr_opted_in_users(self):
+        """Return the set of user_ids that have opted in to /tldr summarization."""
         connection = None
         try:
             connection = self._get_connection()
             cursor = connection.cursor()
-            cursor.execute("SELECT user_id FROM tldr_optouts")
+            cursor.execute("SELECT user_id FROM tldr_optins")
             return {row[0] for row in cursor.fetchall()}
         except mariadb.Error as e:
-            logger.error(f"Error fetching tldr opt-out list: {e}")
+            logger.error(f"Error fetching tldr opt-in list: {e}")
             return set()
         finally:
             if connection:

--- a/database.py
+++ b/database.py
@@ -154,6 +154,13 @@ class DatabaseManager:
             """)
 
             cursor.execute("""
+                CREATE TABLE IF NOT EXISTS tldr_optouts (
+                    user_id BIGINT PRIMARY KEY,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+            cursor.execute("""
                 CREATE TABLE IF NOT EXISTS factcheck_requests (
                     id INT AUTO_INCREMENT PRIMARY KEY,
                     requester_user_id BIGINT NOT NULL,
@@ -1092,6 +1099,71 @@ class DatabaseManager:
         except mariadb.Error as e:
             logger.error(f"Error fetching opted in users count: {e}")
             return 0
+        finally:
+            if connection:
+                connection.close()
+
+    def set_tldr_optout(self, user_id, opted_out):
+        """Opt a user out of (or back into) having their messages summarized by /tldr."""
+        connection = None
+        try:
+            connection = self._get_connection()
+            cursor = connection.cursor()
+            if opted_out:
+                cursor.execute(
+                    """
+                    INSERT INTO tldr_optouts (user_id)
+                    VALUES (?)
+                    ON DUPLICATE KEY UPDATE user_id = user_id
+                """,
+                    (user_id,),
+                )
+            else:
+                cursor.execute(
+                    "DELETE FROM tldr_optouts WHERE user_id = ?",
+                    (user_id,),
+                )
+
+            connection.commit()
+            status = "opted out of" if opted_out else "opted back into"
+            logger.info(f"User {user_id} {status} /tldr summarization")
+            return True
+        except mariadb.Error as e:
+            logger.error(f"Error setting tldr opt-out: {e}")
+            return False
+        finally:
+            if connection:
+                connection.close()
+
+    def is_tldr_opted_out(self, user_id):
+        """Return True if the user has opted out of /tldr summarization."""
+        connection = None
+        try:
+            connection = self._get_connection()
+            cursor = connection.cursor()
+            cursor.execute(
+                "SELECT 1 FROM tldr_optouts WHERE user_id = ?",
+                (user_id,),
+            )
+            return cursor.fetchone() is not None
+        except mariadb.Error as e:
+            logger.error(f"Error fetching tldr opt-out: {e}")
+            return False
+        finally:
+            if connection:
+                connection.close()
+
+    def get_tldr_opted_out_users(self):
+        """Return the set of user_ids that have opted out of /tldr summarization."""
+        connection = None
+        try:
+            connection = self._get_connection()
+            cursor = connection.cursor()
+            cursor.execute("SELECT user_id FROM tldr_optouts")
+            return {row[0] for row in cursor.fetchall()}
+        except mariadb.Error as e:
+            logger.error(f"Error fetching tldr opt-out list: {e}")
+            return set()
         finally:
             if connection:
                 connection.close()

--- a/database.py
+++ b/database.py
@@ -1139,24 +1139,6 @@ class DatabaseManager:
             if connection:
                 connection.close()
 
-    def is_tldr_opted_in(self, user_id):
-        """Return True if the user has opted in to /tldr summarization."""
-        connection = None
-        try:
-            connection = self._get_connection()
-            cursor = connection.cursor()
-            cursor.execute(
-                "SELECT 1 FROM tldr_optins WHERE user_id = ?",
-                (user_id,),
-            )
-            return cursor.fetchone() is not None
-        except mariadb.Error as e:
-            logger.error(f"Error fetching tldr opt-in: {e}")
-            return False
-        finally:
-            if connection:
-                connection.close()
-
     def get_tldr_opted_in_users(self):
         """Return the set of user_ids that have opted in to /tldr summarization."""
         connection = None

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -62,14 +62,20 @@ spec:
                 secretKeyRef:
                   name: discord-bot-secrets
                   key: OPENAI_API_KEY
-            {{- if .Values.vibecode.enabled }}
-            - name: VIBECODE_ENABLED
+            {{- if .Values.tldr.enabled }}
+            - name: TLDR_ENABLED
               value: "true"
+            {{- end }}
+            {{- if or .Values.vibecode.enabled .Values.tldr.enabled }}
             - name: DEEPSEEK_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: discord-bot-secrets
                   key: DEEPSEEK_API_KEY
+            {{- end }}
+            {{- if .Values.vibecode.enabled }}
+            - name: VIBECODE_ENABLED
+              value: "true"
             - name: VIBECODE_GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -134,6 +134,12 @@ env:
   POSTILLON_DELIVERY_DELAY_SECONDS: "1"
   POSTILLON_LEASE_SECONDS: "1800"
 
+  # TL;DR Message Summarization (/tldr) - uses DeepSeek. The TLDR_ENABLED flag
+  # and the shared DEEPSEEK_API_KEY secret are injected separately, gated on
+  # .Values.tldr.enabled (see the tldr block below).
+  TLDR_MODEL: "deepseek-chat"
+  DEEPSEEK_BASE_URL: "https://api.deepseek.com"
+
 # Secrets configuration - using SealedSecrets
 secrets:
   # These should remain empty in values.yaml - secrets come from SealedSecret
@@ -154,4 +160,9 @@ sealedSecrets:
 # Requires DEEPSEEK_API_KEY and VIBECODE_GITHUB_TOKEN in the sealed secret;
 # also adds RBAC so the bot can run worker Jobs in its namespace.
 vibecode:
+  enabled: true
+
+# TL;DR: /tldr summarizes recent channel messages via DeepSeek (opt-in only).
+# Requires DEEPSEEK_API_KEY in the sealed secret (shared with vibecode).
+tldr:
   enabled: true

--- a/main.py
+++ b/main.py
@@ -82,11 +82,11 @@ class DiscordBot(commands.Bot):
                 )
 
             if Config.TLDR_ENABLED:
-                if Config.OPENAI_API_KEY:
+                if Config.DEEPSEEK_API_KEY:
                     await setup_tldr_command(self, self.db_manager)
                 else:
                     logger.error(
-                        "TLDR_ENABLED is true but OPENAI_API_KEY is missing - /tldr disabled"
+                        "TLDR_ENABLED is true but DEEPSEEK_API_KEY is missing - /tldr disabled"
                     )
 
             await self.tree.sync()

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from commands.klugscheisser_command import setup as setup_klugscheisser_command
 from commands.vibecode_command import setup as setup_vibecode_command
 from commands.postillon_command import setup as setup_postillon_command
 from commands.birthday_command import setup as setup_birthday_command
+from commands.tldr_command import setup as setup_tldr_command
 
 logger = setup_logging()
 
@@ -79,6 +80,14 @@ class DiscordBot(commands.Bot):
                     "Neither BIRTHDAY_CHANNEL_ID nor ANNOUNCEMENT_CHANNEL_ID is set "
                     "- birthday greetings will not be delivered"
                 )
+
+            if Config.TLDR_ENABLED:
+                if Config.OPENAI_API_KEY:
+                    await setup_tldr_command(self, self.db_manager)
+                else:
+                    logger.error(
+                        "TLDR_ENABLED is true but OPENAI_API_KEY is missing - /tldr disabled"
+                    )
 
             await self.tree.sync()
             logger.info("Command tree synced successfully")

--- a/tests/test_tldr_command.py
+++ b/tests/test_tldr_command.py
@@ -1,0 +1,166 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+from datetime import timedelta
+
+from commands.tldr_command import TldrCommand
+
+
+class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.bot = MagicMock()
+        self.db = MagicMock()
+        self.openai_key = "fake-key"
+        # patching during each test is clearer; reset per test.
+        self.mock_ai_client = AsyncMock()
+        self.cog_patch = patch(
+            "commands.tldr_command.openai.AsyncOpenAI",
+            return_value=self.mock_ai_client,
+        )
+        self.config_patch = patch(
+            "commands.tldr_command.Config.OPENAI_API_KEY", self.openai_key
+        )
+        self.mock_ai_class = self.cog_patch.start()
+        self.config_patch.start()
+        self.addCleanup(self.cog_patch.stop)
+        self.addCleanup(self.config_patch.stop)
+        self.cog = TldrCommand(self.bot, self.db)
+
+    async def test_tldr_no_api_key_sends_error(self):
+        # re-create cog with missing key
+        with patch(
+            "commands.tldr_command.Config.OPENAI_API_KEY", None
+        ), patch(
+            "commands.tldr_command.openai.AsyncOpenAI"
+        ) as mock_ai:
+            mock_ai.return_value = AsyncMock()
+            cog = TldrCommand(self.bot, self.db)
+
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+        await cog.tldr.callback(cog, interaction, anzahl=50, zeit=None)
+        interaction.followup.send.assert_called_once_with(
+            "❌ OpenAI API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
+            ephemeral=True,
+        )
+
+    async def test_tldr_non_text_channel_returns_error(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.DMChannel)
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=50, zeit=None)
+        interaction.followup.send.assert_called_once_with(
+            "❌ Dieser Befehl funktioniert nur in Textkanälen.",
+            ephemeral=True,
+        )
+
+    async def test_tldr_summarizes_messages(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+
+        fake_user = MagicMock()
+        fake_user.bot = False
+        fake_user.display_name = "Hans"
+        fake_msg1 = MagicMock()
+        fake_msg1.author = fake_user
+        fake_msg1.content = "Hallo Welt"
+        fake_msg2 = MagicMock()
+        fake_msg2.author = fake_user
+        fake_msg2.content = "Wie geht's?"
+
+        async def mock_history(limit=100, after=None):
+            yield fake_msg1
+            yield fake_msg2
+
+        interaction.channel.history = mock_history
+
+        self.mock_ai_client.chat.completions.create = AsyncMock()
+        self.mock_ai_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(message=MagicMock(content="- Jemand hat Hallo Welt gesagt"))
+            ]
+        )
+
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=10, zeit=None)
+
+        interaction.response.defer.assert_called_once_with(ephemeral=False)
+        embed_kwargs = interaction.followup.send.call_args[1]
+        embed = embed_kwargs["embed"]
+        self.assertIsInstance(embed, discord.Embed)
+        self.assertEqual(embed.title, "📝 TL;DR Zusammenfassung")
+        self.assertIn(
+            "- Jemand hat Hallo Welt gesagt", embed.description
+        )
+        self.assertIn("Basierend auf 2 Nachrichten", embed.footer.text)
+
+    async def test_tldr_respects_anzahl_and_zeit_filter(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+
+        fake_user = MagicMock()
+        fake_user.bot = False
+        fake_user.display_name = "Testi"
+
+        # only one message in the future window (we fake time)
+        fresh_msg = MagicMock()
+        fresh_msg.author = fake_user
+        fresh_msg.content = "neue Nachricht"
+
+        stale_msg = MagicMock()
+        stale_msg.author = fake_user
+        stale_msg.content = "alte Nachricht"
+
+        # Override history to filter by after
+        call_after = None
+
+        async def mock_history(limit=100, after=None):
+            nonlocal call_after
+            call_after = after
+            if after is None:
+                yield stale_msg
+            yield fresh_msg
+
+        interaction.channel.history = mock_history
+
+        self.mock_ai_client.chat.completions.create = AsyncMock()
+        self.mock_ai_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(message=MagicMock(content="- jemand hat etwas geschrieben"))
+            ]
+        )
+
+        await self.cog.tldr.callback(
+            self.cog, interaction, anzahl=30, zeit="1h"
+        )
+
+        interaction.response.defer.assert_called_once_with(ephemeral=False)
+        # The stub raises after for 1h
+        self.assertIsNotNone(call_after)
+        embed = interaction.followup.send.call_args[1]["embed"]
+        self.assertIn("Basierend auf 1 Nachrichten", embed.footer.text)
+
+    async def test_tldr_no_messages(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+
+        async def empty_history(limit=100, after=None):
+            if False:
+                yield  # no messages
+
+        interaction.channel.history = empty_history
+
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=5, zeit=None)
+        interaction.followup.send.assert_called_once_with(
+            "Keine Nachrichten gefunden, die zusammengefasst werden können.",
+            ephemeral=True,
+        )

--- a/tests/test_tldr_command.py
+++ b/tests/test_tldr_command.py
@@ -10,7 +10,9 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.bot = MagicMock()
         self.db = MagicMock()
-        self.openai_key = "fake-key"
+        # By default nobody has opted out of /tldr summarization.
+        self.db.get_tldr_opted_out_users.return_value = set()
+        self.deepseek_key = "fake-key"
         # patching during each test is clearer; reset per test.
         self.mock_ai_client = AsyncMock()
         self.cog_patch = patch(
@@ -18,7 +20,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
             return_value=self.mock_ai_client,
         )
         self.config_patch = patch(
-            "commands.tldr_command.Config.OPENAI_API_KEY", self.openai_key
+            "commands.tldr_command.Config.DEEPSEEK_API_KEY", self.deepseek_key
         )
         self.mock_ai_class = self.cog_patch.start()
         self.config_patch.start()
@@ -32,15 +34,15 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         interaction.followup.send = AsyncMock()
         interaction.channel = MagicMock(spec=discord.TextChannel)
 
-        # The command checks Config.OPENAI_API_KEY before doing anything else.
+        # The command checks Config.DEEPSEEK_API_KEY before doing anything else.
         with (
-            patch("commands.tldr_command.Config.OPENAI_API_KEY", None),
+            patch("commands.tldr_command.Config.DEEPSEEK_API_KEY", None),
             patch("commands.tldr_command.openai.AsyncOpenAI", return_value=AsyncMock()),
         ):
             await self.cog.tldr.callback(self.cog, interaction, anzahl=50, zeit=None)
 
         interaction.followup.send.assert_called_once_with(
-            "❌ OpenAI API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
+            "❌ DeepSeek API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
             ephemeral=True,
         )
 
@@ -63,6 +65,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
 
         fake_user = MagicMock()
         fake_user.bot = False
+        fake_user.id = 111
         fake_user.display_name = "Hans"
         fake_msg1 = MagicMock()
         fake_msg1.author = fake_user
@@ -71,7 +74,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         fake_msg2.author = fake_user
         fake_msg2.content = "Wie geht's?"
 
-        async def mock_history(limit=100, after=None):
+        async def mock_history(limit=100, after=None, oldest_first=False):
             yield fake_msg1
             yield fake_msg2
 
@@ -102,6 +105,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
 
         fake_user = MagicMock()
         fake_user.bot = False
+        fake_user.id = 222
         fake_user.display_name = "Testi"
 
         # only one message in the future window (we fake time)
@@ -116,7 +120,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         # Override history to filter by after
         call_after = None
 
-        async def mock_history(limit=100, after=None):
+        async def mock_history(limit=100, after=None, oldest_first=False):
             nonlocal call_after
             call_after = after
             if after is None:
@@ -140,13 +144,85 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         embed = interaction.followup.send.call_args[1]["embed"]
         self.assertIn("Basierend auf 1 Nachrichten", embed.footer.text)
 
+    async def test_tldr_excludes_opted_out_users(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+
+        included_user = MagicMock()
+        included_user.bot = False
+        included_user.id = 1
+        included_user.display_name = "Bleibt"
+
+        opted_out_user = MagicMock()
+        opted_out_user.bot = False
+        opted_out_user.id = 2
+        opted_out_user.display_name = "Raus"
+
+        included_msg = MagicMock()
+        included_msg.author = included_user
+        included_msg.content = "sichtbar"
+
+        excluded_msg = MagicMock()
+        excluded_msg.author = opted_out_user
+        excluded_msg.content = "geheim"
+
+        async def mock_history(limit=100, after=None, oldest_first=False):
+            yield included_msg
+            yield excluded_msg
+
+        interaction.channel.history = mock_history
+        self.db.get_tldr_opted_out_users.return_value = {2}
+
+        self.mock_ai_client.chat.completions.create = AsyncMock()
+        self.mock_ai_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="- zusammenfassung"))]
+        )
+
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=10, zeit=None)
+
+        # Only the opted-in user's message should reach the AI.
+        sent_context = self.mock_ai_client.chat.completions.create.call_args[1][
+            "messages"
+        ][1]["content"]
+        self.assertIn("sichtbar", sent_context)
+        self.assertNotIn("geheim", sent_context)
+
+        embed = interaction.followup.send.call_args[1]["embed"]
+        self.assertIn("Basierend auf 1 Nachrichten", embed.footer.text)
+        self.assertIn("1 ausgeschlossen", embed.footer.text)
+
+    async def test_tldr_optout_persists_preference(self):
+        interaction = MagicMock()
+        interaction.user.id = 42
+        interaction.response.send_message = AsyncMock()
+        self.db.set_tldr_optout.return_value = True
+
+        await self.cog.tldr_optout.callback(self.cog, interaction)
+
+        self.db.set_tldr_optout.assert_called_once_with(42, True)
+        interaction.response.send_message.assert_called_once()
+        self.assertTrue(interaction.response.send_message.call_args[1]["ephemeral"])
+
+    async def test_tldr_optin_persists_preference(self):
+        interaction = MagicMock()
+        interaction.user.id = 42
+        interaction.response.send_message = AsyncMock()
+        self.db.set_tldr_optout.return_value = True
+
+        await self.cog.tldr_optin.callback(self.cog, interaction)
+
+        self.db.set_tldr_optout.assert_called_once_with(42, False)
+        interaction.response.send_message.assert_called_once()
+
     async def test_tldr_no_messages(self):
         interaction = MagicMock()
         interaction.response.defer = AsyncMock()
         interaction.followup.send = AsyncMock()
         interaction.channel = MagicMock(spec=discord.TextChannel)
 
-        async def empty_history(limit=100, after=None):
+        async def empty_history(limit=100, after=None, oldest_first=False):
             if False:
                 yield  # no messages
 

--- a/tests/test_tldr_command.py
+++ b/tests/test_tldr_command.py
@@ -28,20 +28,16 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         self.cog = TldrCommand(self.bot, self.db)
 
     async def test_tldr_no_api_key_sends_error(self):
-        # re-create cog with missing key
-        with patch(
-            "commands.tldr_command.Config.OPENAI_API_KEY", None
-        ), patch(
-            "commands.tldr_command.openai.AsyncOpenAI"
-        ) as mock_ai:
-            mock_ai.return_value = AsyncMock()
-            cog = TldrCommand(self.bot, self.db)
-
         interaction = MagicMock()
         interaction.response.defer = AsyncMock()
         interaction.followup.send = AsyncMock()
         interaction.channel = MagicMock(spec=discord.TextChannel)
-        await cog.tldr.callback(cog, interaction, anzahl=50, zeit=None)
+
+        # The command checks Config.OPENAI_API_KEY before doing anything else.
+        with patch("commands.tldr_command.Config.OPENAI_API_KEY", None), \
+                patch("commands.tldr_command.openai.AsyncOpenAI", return_value=AsyncMock()):
+            await self.cog.tldr.callback(self.cog, interaction, anzahl=50, zeit=None)
+
         interaction.followup.send.assert_called_once_with(
             "❌ OpenAI API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
             ephemeral=True,

--- a/tests/test_tldr_command.py
+++ b/tests/test_tldr_command.py
@@ -32,31 +32,66 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
     async def test_tldr_no_api_key_sends_error(self):
         interaction = MagicMock()
         interaction.response.defer = AsyncMock()
-        interaction.followup.send = AsyncMock()
+        interaction.response.send_message = AsyncMock()
         interaction.channel = MagicMock(spec=discord.TextChannel)
 
-        # The command checks Config.DEEPSEEK_API_KEY before doing anything else.
+        # The command checks Config.DEEPSEEK_API_KEY before deferring, so the
+        # error is a private (ephemeral) initial response, not a follow-up.
         with (
             patch("commands.tldr_command.Config.DEEPSEEK_API_KEY", None),
             patch("commands.tldr_command.openai.AsyncOpenAI", return_value=AsyncMock()),
         ):
             await self.cog.tldr.callback(self.cog, interaction, anzahl=50, zeit=None)
 
-        interaction.followup.send.assert_called_once_with(
+        interaction.response.send_message.assert_called_once_with(
             "❌ DeepSeek API-Schlüssel fehlt. TL;DR kann nicht genutzt werden.",
             ephemeral=True,
         )
+        interaction.response.defer.assert_not_called()
 
     async def test_tldr_non_text_channel_returns_error(self):
         interaction = MagicMock()
         interaction.response.defer = AsyncMock()
-        interaction.followup.send = AsyncMock()
+        interaction.response.send_message = AsyncMock()
         interaction.channel = MagicMock(spec=discord.DMChannel)
         await self.cog.tldr.callback(self.cog, interaction, anzahl=50, zeit=None)
-        interaction.followup.send.assert_called_once_with(
+        interaction.response.send_message.assert_called_once_with(
             "❌ Dieser Befehl funktioniert nur in Textkanälen.",
             ephemeral=True,
         )
+        interaction.response.defer.assert_not_called()
+
+    async def test_tldr_thread_channel_is_allowed(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.Thread)
+
+        user = MagicMock()
+        user.bot = False
+        user.id = 55
+        user.display_name = "Threadi"
+        msg = MagicMock()
+        msg.author = user
+        msg.content = "im Thread"
+
+        async def mock_history(limit=100, after=None, oldest_first=False):
+            yield msg
+
+        interaction.channel.history = mock_history
+        self.db.get_tldr_opted_in_users.return_value = {55}
+
+        self.mock_ai_client.chat.completions.create = AsyncMock(
+            return_value=MagicMock(
+                choices=[MagicMock(message=MagicMock(content="- eine Zusammenfassung"))]
+            )
+        )
+
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=10, zeit=None)
+
+        interaction.response.defer.assert_called_once_with(ephemeral=False)
+        embed = interaction.followup.send.call_args[1]["embed"]
+        self.assertIn("- eine Zusammenfassung", embed.description)
 
     async def test_tldr_summarizes_messages(self):
         interaction = MagicMock()
@@ -235,5 +270,64 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         await self.cog.tldr.callback(self.cog, interaction, anzahl=5, zeit=None)
         interaction.followup.send.assert_called_once_with(
             "Keine Nachrichten gefunden, die zusammengefasst werden können.",
+            ephemeral=True,
+        )
+
+    async def test_tldr_all_skipped_prompts_optin(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+
+        user = MagicMock()
+        user.bot = False
+        user.id = 99
+        user.display_name = "Nope"
+        msg = MagicMock()
+        msg.author = user
+        msg.content = "hallo"
+
+        async def mock_history(limit=100, after=None, oldest_first=False):
+            yield msg
+
+        interaction.channel.history = mock_history
+        # Nobody opted in, so every message is filtered out.
+        self.db.get_tldr_opted_in_users.return_value = set()
+
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=10, zeit=None)
+
+        sent_text = interaction.followup.send.call_args[0][0]
+        self.assertIn("/tldr_optin", sent_text)
+        self.assertTrue(interaction.followup.send.call_args[1]["ephemeral"])
+
+    async def test_tldr_empty_ai_response_reports_error(self):
+        interaction = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+
+        user = MagicMock()
+        user.bot = False
+        user.id = 7
+        user.display_name = "Redner"
+        msg = MagicMock()
+        msg.author = user
+        msg.content = "etwas Sinnvolles"
+
+        async def mock_history(limit=100, after=None, oldest_first=False):
+            yield msg
+
+        interaction.channel.history = mock_history
+        self.db.get_tldr_opted_in_users.return_value = {7}
+
+        # An empty choices list must not crash; it surfaces as a handled error.
+        self.mock_ai_client.chat.completions.create = AsyncMock(
+            return_value=MagicMock(choices=[])
+        )
+
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=10, zeit=None)
+
+        interaction.followup.send.assert_called_once_with(
+            "⚠️ Beim Erstellen der Zusammenfassung ist ein Fehler aufgetreten.",
             ephemeral=True,
         )

--- a/tests/test_tldr_command.py
+++ b/tests/test_tldr_command.py
@@ -10,8 +10,9 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.bot = MagicMock()
         self.db = MagicMock()
-        # By default nobody has opted out of /tldr summarization.
-        self.db.get_tldr_opted_out_users.return_value = set()
+        # /tldr is opt-in only. Tests that expect messages to be summarized
+        # set their authors' ids here explicitly.
+        self.db.get_tldr_opted_in_users.return_value = set()
         self.deepseek_key = "fake-key"
         # patching during each test is clearer; reset per test.
         self.mock_ai_client = AsyncMock()
@@ -79,6 +80,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
             yield fake_msg2
 
         interaction.channel.history = mock_history
+        self.db.get_tldr_opted_in_users.return_value = {111}
 
         self.mock_ai_client.chat.completions.create = AsyncMock()
         self.mock_ai_client.chat.completions.create.return_value = MagicMock(
@@ -128,6 +130,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
             yield fresh_msg
 
         interaction.channel.history = mock_history
+        self.db.get_tldr_opted_in_users.return_value = {222}
 
         self.mock_ai_client.chat.completions.create = AsyncMock()
         self.mock_ai_client.chat.completions.create.return_value = MagicMock(
@@ -144,7 +147,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         embed = interaction.followup.send.call_args[1]["embed"]
         self.assertIn("Basierend auf 1 Nachrichten", embed.footer.text)
 
-    async def test_tldr_excludes_opted_out_users(self):
+    async def test_tldr_includes_only_opted_in_users(self):
         interaction = MagicMock()
         interaction.response.defer = AsyncMock()
         interaction.followup.send = AsyncMock()
@@ -155,17 +158,17 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         included_user.id = 1
         included_user.display_name = "Bleibt"
 
-        opted_out_user = MagicMock()
-        opted_out_user.bot = False
-        opted_out_user.id = 2
-        opted_out_user.display_name = "Raus"
+        not_opted_in_user = MagicMock()
+        not_opted_in_user.bot = False
+        not_opted_in_user.id = 2
+        not_opted_in_user.display_name = "Raus"
 
         included_msg = MagicMock()
         included_msg.author = included_user
         included_msg.content = "sichtbar"
 
         excluded_msg = MagicMock()
-        excluded_msg.author = opted_out_user
+        excluded_msg.author = not_opted_in_user
         excluded_msg.content = "geheim"
 
         async def mock_history(limit=100, after=None, oldest_first=False):
@@ -173,7 +176,8 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
             yield excluded_msg
 
         interaction.channel.history = mock_history
-        self.db.get_tldr_opted_out_users.return_value = {2}
+        # Only user 1 has opted in; user 2 must be excluded by default.
+        self.db.get_tldr_opted_in_users.return_value = {1}
 
         self.mock_ai_client.chat.completions.create = AsyncMock()
         self.mock_ai_client.chat.completions.create.return_value = MagicMock(
@@ -193,27 +197,27 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Basierend auf 1 Nachrichten", embed.footer.text)
         self.assertIn("1 ausgeschlossen", embed.footer.text)
 
-    async def test_tldr_optout_persists_preference(self):
-        interaction = MagicMock()
-        interaction.user.id = 42
-        interaction.response.send_message = AsyncMock()
-        self.db.set_tldr_optout.return_value = True
-
-        await self.cog.tldr_optout.callback(self.cog, interaction)
-
-        self.db.set_tldr_optout.assert_called_once_with(42, True)
-        interaction.response.send_message.assert_called_once()
-        self.assertTrue(interaction.response.send_message.call_args[1]["ephemeral"])
-
     async def test_tldr_optin_persists_preference(self):
         interaction = MagicMock()
         interaction.user.id = 42
         interaction.response.send_message = AsyncMock()
-        self.db.set_tldr_optout.return_value = True
+        self.db.set_tldr_optin.return_value = True
 
         await self.cog.tldr_optin.callback(self.cog, interaction)
 
-        self.db.set_tldr_optout.assert_called_once_with(42, False)
+        self.db.set_tldr_optin.assert_called_once_with(42, True)
+        interaction.response.send_message.assert_called_once()
+        self.assertTrue(interaction.response.send_message.call_args[1]["ephemeral"])
+
+    async def test_tldr_optout_persists_preference(self):
+        interaction = MagicMock()
+        interaction.user.id = 42
+        interaction.response.send_message = AsyncMock()
+        self.db.set_tldr_optin.return_value = True
+
+        await self.cog.tldr_optout.callback(self.cog, interaction)
+
+        self.db.set_tldr_optin.assert_called_once_with(42, False)
         interaction.response.send_message.assert_called_once()
 
     async def test_tldr_no_messages(self):

--- a/tests/test_tldr_command.py
+++ b/tests/test_tldr_command.py
@@ -235,25 +235,71 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
     async def test_tldr_optin_persists_preference(self):
         interaction = MagicMock()
         interaction.user.id = 42
+        interaction.guild_id = 999
         interaction.response.send_message = AsyncMock()
         self.db.set_tldr_optin.return_value = True
 
         await self.cog.tldr_optin.callback(self.cog, interaction)
 
-        self.db.set_tldr_optin.assert_called_once_with(42, True)
+        self.db.set_tldr_optin.assert_called_once_with(999, 42, True)
         interaction.response.send_message.assert_called_once()
         self.assertTrue(interaction.response.send_message.call_args[1]["ephemeral"])
 
     async def test_tldr_optout_persists_preference(self):
         interaction = MagicMock()
         interaction.user.id = 42
+        interaction.guild_id = 999
         interaction.response.send_message = AsyncMock()
         self.db.set_tldr_optin.return_value = True
 
         await self.cog.tldr_optout.callback(self.cog, interaction)
 
-        self.db.set_tldr_optin.assert_called_once_with(42, False)
+        self.db.set_tldr_optin.assert_called_once_with(999, 42, False)
         interaction.response.send_message.assert_called_once()
+
+    async def test_tldr_optin_rejected_in_dm(self):
+        """Opt-in is per guild, so it must not be settable from a DM."""
+        interaction = MagicMock()
+        interaction.user.id = 42
+        interaction.guild_id = None
+        interaction.response.send_message = AsyncMock()
+
+        await self.cog.tldr_optin.callback(self.cog, interaction)
+
+        self.db.set_tldr_optin.assert_not_called()
+        self.assertTrue(interaction.response.send_message.call_args[1]["ephemeral"])
+
+    async def test_tldr_scopes_opt_in_lookup_to_this_guild(self):
+        """The opt-in lookup must be scoped to the guild the command ran in."""
+        interaction = MagicMock()
+        interaction.guild_id = 999
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+
+        user = MagicMock()
+        user.bot = False
+        user.id = 7
+        user.display_name = "Serverbewohner"
+        msg = MagicMock()
+        msg.author = user
+        msg.content = "hallo welt"
+
+        async def mock_history(limit=100, after=None, oldest_first=False):
+            yield msg
+
+        interaction.channel.history = mock_history
+        self.db.get_tldr_opted_in_users.return_value = {7}
+
+        self.mock_ai_client.chat.completions.create = AsyncMock(
+            return_value=MagicMock(
+                choices=[MagicMock(message=MagicMock(content="- Zusammenfassung"))]
+            )
+        )
+
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=10, zeit=None)
+
+        self.db.get_tldr_opted_in_users.assert_called_once_with(999)
 
     async def test_tldr_no_messages(self):
         interaction = MagicMock()

--- a/tests/test_tldr_command.py
+++ b/tests/test_tldr_command.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
-from datetime import timedelta
 
 from commands.tldr_command import TldrCommand
 
@@ -34,8 +33,10 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         interaction.channel = MagicMock(spec=discord.TextChannel)
 
         # The command checks Config.OPENAI_API_KEY before doing anything else.
-        with patch("commands.tldr_command.Config.OPENAI_API_KEY", None), \
-                patch("commands.tldr_command.openai.AsyncOpenAI", return_value=AsyncMock()):
+        with (
+            patch("commands.tldr_command.Config.OPENAI_API_KEY", None),
+            patch("commands.tldr_command.openai.AsyncOpenAI", return_value=AsyncMock()),
+        ):
             await self.cog.tldr.callback(self.cog, interaction, anzahl=50, zeit=None)
 
         interaction.followup.send.assert_called_once_with(
@@ -90,9 +91,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
         embed = embed_kwargs["embed"]
         self.assertIsInstance(embed, discord.Embed)
         self.assertEqual(embed.title, "📝 TL;DR Zusammenfassung")
-        self.assertIn(
-            "- Jemand hat Hallo Welt gesagt", embed.description
-        )
+        self.assertIn("- Jemand hat Hallo Welt gesagt", embed.description)
         self.assertIn("Basierend auf 2 Nachrichten", embed.footer.text)
 
     async def test_tldr_respects_anzahl_and_zeit_filter(self):
@@ -133,9 +132,7 @@ class TestTldrCommand(unittest.IsolatedAsyncioTestCase):
             ]
         )
 
-        await self.cog.tldr.callback(
-            self.cog, interaction, anzahl=30, zeit="1h"
-        )
+        await self.cog.tldr.callback(self.cog, interaction, anzahl=30, zeit="1h")
 
         interaction.response.defer.assert_called_once_with(ephemeral=False)
         # The stub raises after for 1h


### PR DESCRIPTION
Automated change created by the /vibecode Discord command.

Feature request:

ich hätte gerne ein Feature, in dem ich mir die letzten Nachrichten zusammenfassen kann als eine Art TL;DR. Es sollte standardmäßig die letzten, beispielsweise 50 Nachrichten zusammenfassen man sollte aber auch die Möglichkeit haben die Anzahl der Nachrichten variabel als Statement mitzugeben. Zusätzlich wäre es gut, wenn man nicht nur die 50 letzten Nachrichten durchsuchen lassen kann, sondern auch sagen kann ich hätte gerne die Nachrichten der letzten Stunde oder letzten 24 Stunden dieses Channels.

Implemented by aider + deepseek/deepseek-v4-pro. Test suite and ruff verified in the worker before this PR was opened.