### PR TITLE
chore: move bullshitboard demo script out of tests/

### DIFF
--- a/inspect_bullshitboard.py
+++ b/inspect_bullshitboard.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
-"""
-Test script to verify bullshitboard demo data
+"""Print the bullshitboard data currently in the database.
+
+A manual inspection companion to create_demo_data.py: run that to seed
+demo rows, then run this to eyeball how the rankings come out. It asserts
+nothing and needs a live MariaDB, so it is not part of the test suite —
+it lived in tests/ only by filename accident and failed any local
+`pytest tests/` run that had no database.
+
+Usage: python inspect_bullshitboard.py
 """
 
 from database import DatabaseManager
 
 
-def test_bullshitboard():
+def inspect_bullshitboard():
     db = DatabaseManager()
     conn = db._get_connection()
     cursor = conn.cursor()
 
-    print("🎯 BULLSHITBOARD DEMO DATA TEST")
+    print("🎯 BULLSHITBOARD DATA")
     print("=" * 50)
 
     print("\n👥 DEMO USERS:")
@@ -125,8 +132,8 @@ def test_bullshitboard():
         print(f"   {i}. {username} - Avg BS: {avg_score:.2f} ({checks} checks)")
 
     conn.close()
-    print("\n✅ Bullshitboard test completed! The demo data looks great for testing.")
+    print("\n✅ Done.")
 
 
 if __name__ == "__main__":
-    test_bullshitboard()
+    inspect_bullshitboard()


### PR DESCRIPTION
Split out of #30 — unrelated to the `/tldr` feature, so it gets its own PR.

`tests/test_bullshitboard.py` was never a test. It has no assertions; it just prints the bullshitboard rows from a live database. Because it sat in `tests/` under a `test_*` filename with a `test_*` function, a local `pytest tests/` collected it and it failed with an `OperationalError` on any machine without MariaDB running.

CI never caught this because CI never ran it: the test job uses `unittest discover` (which ignores bare functions) plus pytest scoped to `test_e2e_1337.py` only.

**Change:** move it to `inspect_bullshitboard.py` next to its companion `create_demo_data.py`, rename the function off the `test_` prefix, and document what it is in the docstring.

**Result:** `pytest tests/` is green without a database (167 passed). `unittest discover` unchanged (OK). Ruff check + format clean.

Not attempted: turning it into a real test. That needs DB-integration fixtures this repo does not have — every other test mocks `DatabaseManager`.